### PR TITLE
Utiliser le binding de valeurs de knex pour prémunir de l'injection SQL

### DIFF
--- a/lib/application/APIResponse.ts
+++ b/lib/application/APIResponse.ts
@@ -3,22 +3,26 @@ export enum APIResponseStatuses {
   FAILURE = 'failure',
 }
 
-export class APIResponse {
+export class APIResponse<TYPE_DATA> {
   status: APIResponseStatuses;
-  data: any[];
   messages: string[];
+  data: TYPE_DATA[];
 
-  constructor(status: APIResponseStatuses, data: any[], messages: string[]) {
+  constructor(
+    status: APIResponseStatuses,
+    messages: string[],
+    data?: TYPE_DATA[],
+  ) {
     this.status = status;
     this.data = data;
-    this.messages = messages;
+    this.messages = messages || null;
   }
 
-  static success(data: any[]) {
-    return new APIResponse(APIResponseStatuses.SUCCESS, data, []);
+  static success<TYPE_DATA>(data: TYPE_DATA[]): APIResponse<TYPE_DATA> {
+    return new APIResponse<TYPE_DATA>(APIResponseStatuses.SUCCESS, [], data);
   }
 
-  static failure(messages: string[]) {
-    return new APIResponse(APIResponseStatuses.FAILURE, [], messages);
+  static failure(messages: string[]): APIResponse<never> {
+    return new APIResponse(APIResponseStatuses.FAILURE, messages);
   }
 }

--- a/lib/application/query/query.ts
+++ b/lib/application/query/query.ts
@@ -1,11 +1,13 @@
-import { Request, ResponseToolkit } from '@hapi/hapi';
+import { Request, ResponseObject, ResponseToolkit } from '@hapi/hapi';
 import { UserCommand } from '../../domain/models/UserCommand.ts';
 import { Result } from '../../domain/models/Result.ts';
 import { executeQueryUseCase } from '../../domain/usecases/ExecuteQueryUsecase.ts';
 import { APIResponse } from '../APIResponse.ts';
-import { DatamartResponse } from '../../domain/models/DatamartResponse.ts';
 
-export async function execute(clientRequest: Request, h: ResponseToolkit) {
+export async function execute(
+  clientRequest: Request,
+  h: ResponseToolkit,
+): Promise<ResponseObject> {
   const userCommandValidationResult: Result<UserCommand> =
     UserCommand.buildFromPayload(clientRequest.payload);
   if (userCommandValidationResult.isFailure) {
@@ -14,10 +16,9 @@ export async function execute(clientRequest: Request, h: ResponseToolkit) {
       .code(400);
   }
 
-  const queryExecutionResult: Result<DatamartResponse> =
-    await executeQueryUseCase.executeQuery(
-      userCommandValidationResult.resultData,
-    );
+  const queryExecutionResult = await executeQueryUseCase.executeQuery(
+    userCommandValidationResult.resultData,
+  );
   if (queryExecutionResult.isFailure) {
     return h
       .response(APIResponse.failure(queryExecutionResult.errorMessages))

--- a/lib/common/db/seeds/seed.js
+++ b/lib/common/db/seeds/seed.js
@@ -7,7 +7,7 @@ const seed = async function (knex) {
 
   await knex('catalog_queries').insert({
     sql_query:
-      'SELECT id, nom, region, departements FROM data_ref_academies WHERE id IN ({{id_list}})',
+      'SELECT id, nom, region, departements FROM data_ref_academies WHERE id = any({{ id_list }})',
     id: 'b1e20492-8775-47f3-926d-3729ee2b836d',
     created_at: new Date('2022-05-14T13:24:00Z'),
   });

--- a/lib/domain/models/DatamartResponse.ts
+++ b/lib/domain/models/DatamartResponse.ts
@@ -1,4 +1,3 @@
 export type DatamartResponse = {
   result: string;
-  count: number;
 };

--- a/lib/domain/models/Result.ts
+++ b/lib/domain/models/Result.ts
@@ -1,27 +1,27 @@
 export class Result<ResultData> {
   isSuccess: boolean;
   errorMessages: string[];
-  resultData?: ResultData;
+  resultData: ResultData;
 
   constructor(
     isSuccess: boolean,
     errorMessages: string[],
-    resultData: ResultData,
+    resultData?: ResultData,
   ) {
     this.isSuccess = isSuccess;
     this.errorMessages = errorMessages;
-    this.resultData = resultData;
+    this.resultData = resultData || null;
   }
 
   get isFailure() {
     return !this.isSuccess;
   }
 
-  static success(resultData: any) {
-    return new Result(true, [], resultData);
+  static success<ResultData>(resultData: ResultData): Result<ResultData> {
+    return new Result<ResultData>(true, [], resultData);
   }
 
-  static failure(errorMessages: string[]) {
-    return new Result(false, errorMessages, null);
+  static failure(errorMessages: string[]): Result<never> {
+    return new Result<never>(false, errorMessages);
   }
 }

--- a/lib/domain/usecases/ExecuteQueryUsecase.ts
+++ b/lib/domain/usecases/ExecuteQueryUsecase.ts
@@ -13,7 +13,7 @@ import { QueryCatalogItem } from '../models/QueryCatalogItem.ts';
 import { Result } from '../models/Result.ts';
 
 export interface ExecuteQueryUseCase {
-  executeQuery(_userCommand: UserCommand): Promise<Result<DatamartResponse>>;
+  executeQuery(_userCommand: UserCommand): Promise<Result<string>>;
 }
 class ExecuteQueryUseCaseImpl implements ExecuteQueryUseCase {
   constructor(
@@ -24,9 +24,7 @@ class ExecuteQueryUseCaseImpl implements ExecuteQueryUseCase {
     this.catalogQueryRepository = catalogQueryRepository;
   }
 
-  async executeQuery(
-    userCommand: UserCommand,
-  ): Promise<Result<DatamartResponse>> {
+  async executeQuery(userCommand: UserCommand): Promise<Result<string>> {
     const queryCatalogItem: QueryCatalogItem =
       await this.catalogQueryRepository.find(userCommand.queryId);
     if (!queryCatalogItem.query) {
@@ -44,7 +42,7 @@ class ExecuteQueryUseCaseImpl implements ExecuteQueryUseCase {
     const datamartResponse = await this.datamartRepository.find(
       datamartQueryModel,
     );
-    return Result.success(datamartResponse);
+    return Result.success(datamartResponse.result);
   }
 }
 

--- a/lib/infrastructure/DatamartRepository.ts
+++ b/lib/infrastructure/DatamartRepository.ts
@@ -16,7 +16,9 @@ class DatamartRepositoryImpl implements DatamartRepository {
       const knexQuery = queryBuilder.build();
       // eslint-disable-next-line knex/avoid-injections
       const result = await knexDatamart.raw(knexQuery.query, knexQuery.params);
-      return result['rows'];
+      return {
+        result: result['rows'],
+      } as DatamartResponse;
     } catch (e) {
       logger.error(
         `Error while executing query: ${datamartQueryModel.query}`,

--- a/lib/infrastructure/DatamartRepository.ts
+++ b/lib/infrastructure/DatamartRepository.ts
@@ -13,8 +13,9 @@ class DatamartRepositoryImpl implements DatamartRepository {
   ): Promise<DatamartResponse> {
     const queryBuilder = new QueryBuilder(datamartQueryModel);
     try {
+      const knexQuery = queryBuilder.build();
       // eslint-disable-next-line knex/avoid-injections
-      const result = await knexDatamart.raw(queryBuilder.build());
+      const result = await knexDatamart.raw(knexQuery.query, knexQuery.params);
       return result['rows'];
     } catch (e) {
       logger.error(

--- a/tests/acceptance/query_test.ts
+++ b/tests/acceptance/query_test.ts
@@ -27,7 +27,6 @@ describe('Acceptance | query', function () {
       expect(response.statusCode).to.equal(400);
       expect(JSON.parse(response.payload)).to.deep.equal({
         status: 'failure',
-        data: [],
         messages: [
           'unknown attribute: "queryIdddddddd"',
           '"queryId" is mandatory',
@@ -96,7 +95,6 @@ describe('Acceptance | query', function () {
           expect(response.statusCode).to.equal(422);
           expect(JSON.parse(response.payload)).to.deep.equal({
             status: 'failure',
-            data: [],
             messages: ['cannot run requested query'],
           });
         });

--- a/tests/unit/infrastructure/builder/QueryBuilder_test.ts
+++ b/tests/unit/infrastructure/builder/QueryBuilder_test.ts
@@ -19,7 +19,10 @@ describe('Unit | Query builder', function () {
       const queryResult = queryBuilder.build();
 
       // then
-      expect(queryResult).to.equal('select * from table_exemple\nwhere id = 1');
+      expect(queryResult).to.deep.equal({
+        query: 'select * from table_exemple\nwhere id = 1',
+        params: {},
+      });
     });
     it('it should return a query with mandatory param', function () {
       // given
@@ -46,154 +49,83 @@ describe('Unit | Query builder', function () {
       const queryResult = queryBuilder.build();
 
       // then
-      expect(queryResult).to.equal(
-        "select * from table_exemple where id = 'valeur à injecter'",
-      );
+      expect(queryResult).to.deep.equal({
+        query: 'select * from table_exemple where id = :injectString',
+        params: { injectString: 'valeur à injecter' },
+      });
     });
-    it('with param array int', function () {
+    it('with every parameter type params', function () {
       // given
       const datamartQueryModel = new DatamartQueryModel({
-        query: 'select * from table_exemple where id in ({{ param }})',
+        query:
+          'select * from table_exemple where id = any({{ paramIntArray }}) and date = {{ paramDate }} and floatParam = any({{ paramFloatArray }}) and paramString = any({{ paramStringArray }}) and univers = {{ paramBoolean }}',
         paramValues: [
           {
-            name: 'param',
+            name: 'paramIntArray',
             value: [1, 2],
           },
-        ],
-        paramDefinitions: [
           {
-            name: 'param',
-            type: ParamType.INT_ARRAY,
-            mandatory: true,
-          },
-        ],
-      });
-
-      const queryBuilder = new QueryBuilder(datamartQueryModel);
-
-      // when
-      const queryResult = queryBuilder.build();
-
-      // then
-      expect(queryResult).to.equal(
-        'select * from table_exemple where id in (1, 2)',
-      );
-    });
-    it('with param date', function () {
-      // given
-      const datamartQueryModel = new DatamartQueryModel({
-        query: 'select * from table_exemple where status = {{ param }}',
-        paramValues: [
-          {
-            name: 'param',
+            name: 'paramDate',
             value: '2013-07-21 15:18:34',
           },
-        ],
-        paramDefinitions: [
           {
-            name: 'param',
-            type: ParamType.DATE,
-            mandatory: true,
-          },
-        ],
-      });
-
-      const queryBuilder = new QueryBuilder(datamartQueryModel);
-
-      // when
-      const queryResult = queryBuilder.build();
-
-      // then
-      expect(queryResult).to.equal(
-        "select * from table_exemple where status = '2013-07-21 15:18:34'",
-      );
-    });
-    it('with param array float', function () {
-      // given
-      const datamartQueryModel = new DatamartQueryModel({
-        query: 'select * from table_exemple where id in ({{ param }})',
-        paramValues: [
-          {
-            name: 'param',
+            name: 'paramFloatArray',
             value: [1.2, 2],
           },
-        ],
-        paramDefinitions: [
           {
-            name: 'param',
-            type: ParamType.FLOAT_ARRAY,
-            mandatory: true,
-          },
-        ],
-      });
-
-      const queryBuilder = new QueryBuilder(datamartQueryModel);
-
-      // when
-      const queryResult = queryBuilder.build();
-
-      // then
-      expect(queryResult).to.equal(
-        'select * from table_exemple where id in (1.2, 2)',
-      );
-    });
-    it('with param array string', function () {
-      // given
-      const datamartQueryModel = new DatamartQueryModel({
-        query: 'select * from table_exemple where id in ({{ param }})',
-        paramValues: [
-          {
-            name: 'param',
+            name: 'paramStringArray',
             value: ['value1', 'value2'],
           },
-        ],
-        paramDefinitions: [
           {
-            name: 'param',
-            type: ParamType.STRING_ARRAY,
-            mandatory: true,
-          },
-        ],
-      });
-
-      const queryBuilder = new QueryBuilder(datamartQueryModel);
-
-      // when
-      const queryResult = queryBuilder.build();
-
-      // then
-      expect(queryResult).to.equal(
-        "select * from table_exemple where id in ('value1', 'value2')",
-      );
-    });
-    it('with param array boolean', function () {
-      // given
-      const datamartQueryModel = new DatamartQueryModel({
-        query: 'select * from table_exemple where status = {{ param }}',
-        paramValues: [
-          {
-            name: 'param',
+            name: 'paramBoolean',
             value: true,
           },
         ],
         paramDefinitions: [
           {
-            name: 'param',
+            name: 'paramIntArray',
+            type: ParamType.INT_ARRAY,
+            mandatory: true,
+          },
+          {
+            name: 'paramDate',
+            type: ParamType.DATE,
+            mandatory: true,
+          },
+          {
+            name: 'paramFloatArray',
+            type: ParamType.FLOAT_ARRAY,
+            mandatory: true,
+          },
+          {
+            name: 'paramStringArray',
+            type: ParamType.STRING_ARRAY,
+            mandatory: true,
+          },
+          {
+            name: 'paramBoolean',
             type: ParamType.BOOLEAN,
             mandatory: true,
           },
         ],
       });
-
       const queryBuilder = new QueryBuilder(datamartQueryModel);
 
       // when
       const queryResult = queryBuilder.build();
 
       // then
-      expect(queryResult).to.equal(
-        'select * from table_exemple where status = true',
-      );
+      expect(queryResult).to.deep.equal({
+        query:
+          'select * from table_exemple where id = any(:paramIntArray) and date = :paramDate and floatParam = any(:paramFloatArray) and paramString = any(:paramStringArray) and univers = :paramBoolean',
+        params: {
+          paramIntArray: [1, 2],
+          paramDate: '2013-07-21 15:18:34',
+          paramFloatArray: [1.2, 2],
+          paramStringArray: ['value1', 'value2'],
+          paramBoolean: true,
+        },
+      });
     });
   });
   context('query with optional block definition', function () {
@@ -212,7 +144,10 @@ describe('Unit | Query builder', function () {
       const queryResult = queryBuilder.build();
 
       // then
-      expect(queryResult).to.equal('select * from table_exemple where id = 1');
+      expect(queryResult).to.deep.equal({
+        query: 'select * from table_exemple where id = 1',
+        params: {},
+      });
     });
     it('it should return a query with one optional block', function () {
       // given
@@ -240,9 +175,11 @@ describe('Unit | Query builder', function () {
       const queryResult = queryBuilder.build();
 
       // then
-      expect(queryResult).to.equal(
-        "select * from table_exemple where id = 1  AND optional = 'valeur à injecter'",
-      );
+      expect(queryResult).to.deep.equal({
+        query:
+          'select * from table_exemple where id = 1  AND optional = :optionalParam',
+        params: { optionalParam: 'valeur à injecter' },
+      });
     });
     it('it should return query with only one optional block of two', function () {
       // given
@@ -275,9 +212,11 @@ describe('Unit | Query builder', function () {
       const queryResult = queryBuilder.build();
 
       // then
-      expect(queryResult).to.equal(
-        "select * from table_exemple where id = 1 \n\n  AND optional2 = 'valeur à injecter2'",
-      );
+      expect(queryResult).to.deep.equal({
+        query:
+          'select * from table_exemple where id = 1 \n\n  AND optional2 = :optionalParam2',
+        params: { optionalParam2: 'valeur à injecter2' },
+      });
     });
     it('it should return good query when have some optional block', function () {
       // given
@@ -314,9 +253,14 @@ describe('Unit | Query builder', function () {
       const queryResult = queryBuilder.build();
 
       // then
-      expect(queryResult).to.equal(
-        "select * from table_exemple where id = 1 \n AND optional \n= 'valeur à injecter' \n  AND optional2 = 'valeur à injecter2'",
-      );
+      expect(queryResult).to.deep.equal({
+        query:
+          'select * from table_exemple where id = 1 \n AND optional \n= :optionalParam \n  AND optional2 = :optionalParam2',
+        params: {
+          optionalParam: 'valeur à injecter',
+          optionalParam2: 'valeur à injecter2',
+        },
+      });
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Pas de prévention des injections SQL dans les paramètres.

## :robot: Proposition
Utiliser le binding de valeurs de knex.
