### PR TITLE
[BUGFIX] Une méthode de logger inexistante est utilisée dans le PgClient

### DIFF
--- a/lib/common/db/PgClient.js
+++ b/lib/common/db/PgClient.js
@@ -26,10 +26,10 @@ class PgClient {
   }
 
   query_and_log(query) {
-    logger.log(`query: ${query}`);
+    logger.info(`query: ${query}`);
     return this.client.query(query).then((result) => {
       const { command, rowCount, rows } = result;
-      logger.log(
+      logger.info(
         `result: command ${command} (rowCount ${rowCount}) = ${JSON.stringify(
           rows,
         )}`,


### PR DESCRIPTION
## :unicorn: Problème
PgClient utilise logger.log, ça n'existe pas.

## :robot: Proposition
On remplace par logger.info

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
