### PR TITLE
[TECH] Amélioration des logs de réponses

### DIFF
--- a/lib/common/logger/Logger.ts
+++ b/lib/common/logger/Logger.ts
@@ -1,6 +1,7 @@
 import * as pino from 'pino';
 import * as pinoPretty from 'pino-pretty';
 import { config } from '../config.js';
+import { stdSerializers } from 'pino';
 
 const { logging } = config;
 
@@ -20,6 +21,7 @@ export const logger = pino.default(
     level: logging.logLevel,
     redact: ['req.headers.authorization'],
     enabled: logging.enabled,
+    serializers: Object.assign(Object.create(null), stdSerializers),
   },
   prettyPrint,
 );

--- a/lib/common/logger/plugins/pino.ts
+++ b/lib/common/logger/plugins/pino.ts
@@ -1,6 +1,7 @@
 import { logger } from '../Logger.js';
-import type { Server, Plugin } from '@hapi/hapi';
+import type { Plugin, Server } from '@hapi/hapi';
 import type { Logger } from 'pino';
+
 const plugin: Plugin<unknown> = {
   name: 'hapi-pino',
   register: async (server: Server, options: Options): Promise<void> => {
@@ -38,19 +39,18 @@ const plugin: Plugin<unknown> = {
     server.events.on('response', (request): void => {
       const info = request.info;
 
-      logger.info({
-        method: request.method,
-        path: request.path,
-        queryParams: request.query,
-        responseTime:
-          (info.completed !== undefined ? info.completed : info.responded) -
-          info.received,
-        status: 'request completed',
-      });
-      logger.trace({
-        req: request,
-        res: request.raw.res,
-      });
+      logger.info(
+        {
+          queryParams: request.query,
+          responseTime:
+            (info.completed !== undefined ? info.completed : info.responded) -
+            info.received,
+          payload: request.auth.isAuthenticated ? request.payload : {},
+          req: request,
+          res: request.raw.res,
+        },
+        'request completed',
+      );
     });
   },
 };


### PR DESCRIPTION
## :unicorn: Problème
Les logs étaient tout pourris.

## :robot: Proposition
Envoi et sérialisation des infos de requête et réponse nécessaires au pipeline "hapi response log" de Datadog, et à la création de métriques sur les temps de réponses de l'API /query (par id de query / params).

## :100: Pour tester
Appeler les endpoints /token et /query avec et sans params.
Les logs sont plus sympas, non ?
