### PR TITLE
[TECH] Monter la version des images postgresql

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,12 +39,12 @@ executors:
         type: string
     docker:
       - image: cimg/node:<<parameters.node-version>>
-      - image: postgres:14.6-alpine
+      - image: postgres:14.10-alpine
         name: pg-api
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
-      - image: postgres:14.6-alpine
+      - image: postgres:14.10-alpine
         name: pg-datamart
         environment:
           POSTGRES_USER: circleci

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   postgres-api:
-    image: postgres:14.6-alpine
+    image: postgres:14.10-alpine
     container_name: pix-api-data-postgres
     ports:
       - '${PIX_DATABASE_PORT_API:-5455}:5432'
@@ -13,7 +13,7 @@ services:
       - .env
 
   postgres-datamart:
-    image: postgres:14.6-alpine
+    image: postgres:14.10-alpine
     container_name: pix-api-data-postgres-datamart
     ports:
       - '${PIX_DATABASE_PORT_DATAMART:-5456}:5432'


### PR DESCRIPTION
## :christmas_tree: Problème

Une nouvelle version de l'addon postgresqlest proposée par Scalingo et la montée de version va être effectuée. Cependant, les images docker sont encore sur les anciennes versions.

## :gift: Proposition

Mettre à jour la version de l'image postgresql de la version 14.8 à la version 14.10

## :santa: Pour tester
🟢 
