### PR TITLE
[FEATURE] Faciliter le merge des PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,23 @@
+name: automerge check
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+  check_suite:
+    types:
+      - completed
+  status:
+    types:
+      - success
+
+permissions: {}
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: 1024pix/pix-actions/auto-merge@v0
+        with:
+          auto_merge_token: '${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}'


### PR DESCRIPTION
## :unicorn: Problème
Nous n'avons pas l'action auto-merge comme sur les autre repo ce qui ne permet pas d'avoir un unique workflow GitHub, ne garantit pas que le titre de la PR finit en titre de merge et un historique linéaire.

## :robot: Proposition
Ajouter l'action

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
