### PR TITLE
[FEATURE] Restreindre l'usage des requêtes (PIX-13217).

### DIFF
--- a/lib/application/query/query.ts
+++ b/lib/application/query/query.ts
@@ -8,8 +8,10 @@ export async function execute(
   clientRequest: Request,
   h: ResponseToolkit,
 ): Promise<ResponseObject> {
+  const requesterId = clientRequest.auth.credentials['userId'];
+
   const userCommandValidationResult: Result<UserCommand> =
-    UserCommand.buildFromPayload(clientRequest.payload);
+    UserCommand.buildFromPayload(clientRequest.payload, requesterId);
   if (userCommandValidationResult.isFailure) {
     return h
       .response(APIResponse.failure(userCommandValidationResult.errorMessages))

--- a/lib/common/db/migrations/20240628140218_create-query-access-table.js
+++ b/lib/common/db/migrations/20240628140218_create-query-access-table.js
@@ -1,0 +1,17 @@
+const TABLE_NAME = 'query_access';
+
+const up = (knex) => {
+  return knex.schema.createTable(TABLE_NAME, (t) => {
+    t.uuid('user_id').notNullable();
+    t.uuid('query_id').notNullable();
+    t.primary(['user_id', 'query_id']);
+    t.foreign('user_id').references('id').inTable('users');
+    t.foreign('query_id').references('id').inTable('catalog_queries');
+  });
+};
+
+const down = (knex) => {
+  return knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };

--- a/lib/common/db/migrations/20240628140638_create-query-param-access-table.js
+++ b/lib/common/db/migrations/20240628140638_create-query-param-access-table.js
@@ -1,0 +1,20 @@
+const TABLE_NAME = 'query_param_access';
+
+const up = (knex) => {
+  return knex.schema.createTable(TABLE_NAME, (t) => {
+    t.uuid('id').primary().defaultTo(knex.fn.uuid());
+    t.uuid('user_id').notNullable();
+    t.integer('query_param_id').notNullable();
+    t.string('value').notNullable();
+    t.foreign('user_id').references('id').inTable('users');
+    t.foreign('query_param_id')
+      .references('id')
+      .inTable('catalog_query_params');
+  });
+};
+
+const down = (knex) => {
+  return knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };

--- a/lib/common/db/seeds/seed.js
+++ b/lib/common/db/seeds/seed.js
@@ -11,14 +11,17 @@ const seed = async function (knex) {
     created_at: new Date('2021-10-29T03:04:00Z'),
   });
 
+  const refAcademiesQueryId = 'b1e20492-8775-47f3-926d-3729ee2b836d';
+
   await knex('catalog_queries').insert({
     sql_query:
       'SELECT id, nom, region, departements FROM data_ref_academies WHERE id = any({{ id_list }})',
-    id: 'b1e20492-8775-47f3-926d-3729ee2b836d',
+    id: refAcademiesQueryId,
     created_at: new Date('2022-05-14T13:24:00Z'),
   });
   await knex('catalog_query_params').insert({
-    catalog_query_id: 'b1e20492-8775-47f3-926d-3729ee2b836d',
+    id: 1,
+    catalog_query_id: refAcademiesQueryId,
     name: 'id_list',
     type: 'int-array',
     mandatory: true,
@@ -28,12 +31,30 @@ const seed = async function (knex) {
     "LeMotDePasseQueL'UtilisateurUtiliseraitDeSonPointDeVue",
     _getNumber(process.env['BCRYPT_NUMBER_OF_SALT_ROUNDS'], 10),
   );
+
+  const userId = '456f9d47-39a7-4de6-ada2-e47662b79bf3';
   await knex('users').insert({
-    id: '456f9d47-39a7-4de6-ada2-e47662b79bf3',
+    id: userId,
     username: 'dev',
     label: 'Utilisateur de test',
     hashed_password: hashedPassword,
     created_at: new Date('2021-10-29T03:04:00Z'),
+  });
+
+  await knex('query_access').insert({
+    user_id: userId,
+    query_id: refAcademiesQueryId,
+  });
+
+  await knex('query_param_access').insert({
+    user_id: userId,
+    query_param_id: 1,
+    value: '2',
+  });
+  await knex('query_param_access').insert({
+    user_id: userId,
+    query_param_id: 1,
+    value: '4',
   });
 };
 

--- a/lib/domain/commands/UserCommand.ts
+++ b/lib/domain/commands/UserCommand.ts
@@ -4,13 +4,22 @@ import { Result } from '../models/Result.js';
 export class UserCommand {
   queryId: UUID;
   params: UserCommandParam[];
+  requesterId: UUID
 
-  constructor(queryId: UUID, params: UserCommandParam[]) {
+  constructor(queryId: UUID, params: UserCommandParam[], requesterId: UUID) {
     this.queryId = queryId;
     this.params = params;
+    this.requesterId = requesterId;
   }
 
-  static buildFromPayload(payload: unknown): Result<UserCommand> {
+  static buildFromPayload(
+    payload: unknown,
+    requesterId: unknown,
+  ): Result<UserCommand> {
+    if (!isValidUUID(requesterId)) {
+      return Result.failure(['"requesterId" is not a valid UUID']);
+    }
+
     const { messages, validatedPayload } = validatePayload(payload);
     if (messages.length > 0) {
       return Result.failure(messages);
@@ -19,6 +28,7 @@ export class UserCommand {
     const userCommand = new UserCommand(
       validatedPayload.queryId,
       validatedPayload.params,
+      requesterId,
     );
     return Result.success(userCommand);
   }

--- a/lib/domain/errors.ts
+++ b/lib/domain/errors.ts
@@ -1,0 +1,5 @@
+export class NotFoundError extends Error {
+  constructor(message) {
+    super(message);
+  }
+}

--- a/lib/domain/models/QueryAccess.ts
+++ b/lib/domain/models/QueryAccess.ts
@@ -1,0 +1,11 @@
+export type QueryAccess = {
+  [key: string]: string[];
+};
+
+export class QueryAccessModel {
+  constructor(private queryAccess: QueryAccess) {}
+
+  get paramsAccess() {
+    return this.queryAccess;
+  }
+}

--- a/lib/domain/models/QueryAccess.ts
+++ b/lib/domain/models/QueryAccess.ts
@@ -1,3 +1,5 @@
+import type { UserCommandParam } from '../commands/UserCommand.js';
+
 export type QueryAccess = {
   [key: string]: string[];
 };
@@ -7,5 +9,11 @@ export class QueryAccessModel {
 
   get paramsAccess() {
     return this.queryAccess;
+  }
+
+  areParamsValid(params: UserCommandParam[]): boolean {
+    return params.every((param) => {
+      return this.queryAccess[param.name]?.includes(param.value.toString());
+    });
   }
 }

--- a/lib/domain/usecases/ExecuteQueryUsecase.ts
+++ b/lib/domain/usecases/ExecuteQueryUsecase.ts
@@ -6,6 +6,10 @@ import {
   DatamartRepository,
   datamartRepository,
 } from '../../infrastructure/DatamartRepository.js';
+import {
+  type QueryAccessRepository,
+  queryAccessRepository,
+} from '../../infrastructure/QueryAccessRepository.js';
 import type { UserCommand } from '../commands/UserCommand.js';
 import { DatamartQueryModel } from '../models/DatamartQuery.js';
 import type { DatamartResponse } from '../models/DatamartResponse.js';
@@ -20,9 +24,11 @@ export class ExecuteQueryUseCaseImpl implements ExecuteQueryUseCase {
   constructor(
     private readonly datamartRepository: DatamartRepository,
     private readonly catalogQueryRepository: CatalogQueryRepository,
+    private readonly queryAccessRepository: QueryAccessRepository,
   ) {
     this.datamartRepository = datamartRepository;
     this.catalogQueryRepository = catalogQueryRepository;
+    this.queryAccessRepository = queryAccessRepository;
   }
 
   async executeQuery(
@@ -32,6 +38,19 @@ export class ExecuteQueryUseCaseImpl implements ExecuteQueryUseCase {
       await this.catalogQueryRepository.find(userCommand.queryId);
     if (!queryCatalogItem.query) {
       return Result.failure(['cannot run requested query']);
+    }
+
+    try {
+      const queryAccess = await this.queryAccessRepository.get(
+        userCommand.queryId,
+        userCommand.requesterId,
+      );
+
+      if (!queryAccess.areParamsValid(userCommand.params)) {
+        return Result.failure(['No access to requested params']);
+      }
+    } catch (e) {
+      return Result.failure(['User is not allowed to run this query']);
     }
 
     const datamartQueryModel = new DatamartQueryModel({
@@ -50,4 +69,8 @@ export class ExecuteQueryUseCaseImpl implements ExecuteQueryUseCase {
 }
 
 export const executeQueryUseCase: ExecuteQueryUseCase =
-  new ExecuteQueryUseCaseImpl(datamartRepository, catalogQueryRepository);
+  new ExecuteQueryUseCaseImpl(
+    datamartRepository,
+    catalogQueryRepository,
+    queryAccessRepository,
+  );

--- a/lib/infrastructure/QueryAccessRepository.ts
+++ b/lib/infrastructure/QueryAccessRepository.ts
@@ -1,0 +1,59 @@
+import type { UUID } from 'crypto';
+
+import { knexAPI } from '../common/db/knex-database-connections.js';
+import { NotFoundError } from '../domain/errors.js';
+import {
+  type QueryAccess,
+  QueryAccessModel,
+} from '../domain/models/QueryAccess.js';
+
+export interface QueryAccessRepository {
+  get(_queryId: UUID, _userId: UUID): Promise<QueryAccessModel>;
+}
+
+type queryParamsAccessDTO = {
+  name: string;
+  value: string;
+};
+
+class QueryAccessRepositoryImpl implements QueryAccessRepository {
+  async get(queryId: UUID, userId: UUID): Promise<QueryAccessModel> {
+    const queryAccess = await knexAPI('query_access')
+      .where('user_id', userId)
+      .where('query_id', queryId)
+      .first();
+
+    if (!queryAccess) {
+      throw new NotFoundError('Query access not found');
+    }
+
+    const queryParamsAccessDTO: queryParamsAccessDTO[] = await knexAPI('query_param_access')
+      .select(['name', 'value'])
+      .innerJoin(
+        'catalog_query_params',
+        'query_param_access.query_param_id',
+        'catalog_query_params.id',
+      )
+      .where('catalog_query_id', queryId)
+      .where('user_id', userId);
+
+    const queryParamsAccess = transformToQueryAccess(queryParamsAccessDTO);
+    return new QueryAccessModel(queryParamsAccess);
+  }
+}
+
+function transformToQueryAccess(
+  queryParams: queryParamsAccessDTO[],
+): QueryAccess {
+  return queryParams.reduce((acc, queryParamAccess) => {
+    if (acc[queryParamAccess.name]) {
+      acc[queryParamAccess.name].push(queryParamAccess.value);
+    } else {
+      acc[queryParamAccess.name] = [queryParamAccess.value];
+    }
+    return acc;
+  }, {}) as QueryAccess;
+}
+
+export const QueryAccessRepository: QueryAccessRepository =
+  new QueryAccessRepositoryImpl();

--- a/lib/infrastructure/QueryAccessRepository.ts
+++ b/lib/infrastructure/QueryAccessRepository.ts
@@ -55,5 +55,5 @@ function transformToQueryAccess(
   }, {}) as QueryAccess;
 }
 
-export const QueryAccessRepository: QueryAccessRepository =
+export const queryAccessRepository: QueryAccessRepository =
   new QueryAccessRepositoryImpl();

--- a/tests/acceptance/application/query_test.ts
+++ b/tests/acceptance/application/query_test.ts
@@ -4,12 +4,14 @@ import {
   knexAPI,
   generateValidRequestAuthorizationHeader,
 } from '../../test-helper.js';
+import { UUID } from 'crypto';
 
 describe('Acceptance | query', function () {
   let headers: string;
+  let userId: UUID;
 
   beforeEach(async function () {
-    const userId = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+    userId = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
     await knexAPI('users').insert({
       id: userId,
       username: 'gigi_lamoroso',
@@ -20,6 +22,7 @@ describe('Acceptance | query', function () {
   });
 
   afterEach(async function () {
+    await knexAPI('query_access').delete();
     await knexAPI('users').delete();
     await knexAPI('catalog_queries').delete();
   });
@@ -55,41 +58,84 @@ describe('Acceptance | query', function () {
 
   context('when payload is valid', function () {
     context('when "queryId" refers to an existing query', function () {
-      it('should return a proper payload response with status code 200', async function () {
-        // given
-        const queryId = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
-        await knexAPI('catalog_queries').insert({
-          id: queryId,
-          sql_query: 'SELECT COUNT(*) FROM public.data_ref_academies',
-        });
-        const payload = {
-          queryId,
-          params: <any>[],
-        };
+      context('when user is not authorized to run the query', function () {
+        it('should return a proper error with status code 403', async function () {
+          // given
+          const queryId = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+          await knexAPI('catalog_queries').insert({
+            id: queryId,
+            sql_query: 'SELECT COUNT(*) FROM public.data_ref_academies',
+          });
+          await knexAPI('query_access').insert({
+            query_id: queryId,
+            user_id: userId,
+          });
+          const payload = {
+            queryId,
+            params: <any>[],
+          };
 
-        // when
-        const server = await createServer();
-        const response = await server.inject({
-          method: 'POST',
-          url: '/query',
-          payload,
-          headers: { authorization: headers },
+          // when
+          const server = await createServer();
+          const response = await server.inject({
+            method: 'POST',
+            url: '/query',
+            payload,
+            headers: { authorization: headers },
+          });
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          expect(JSON.parse(response.payload)).to.deep.equal({
+            status: 'success',
+            data: [{ count: 33 }],
+            messages: [],
+          });
+        });
+      });
+
+      context('when user is authorized to run the query', function () {
+        it('should return a proper payload response with status code 200', async function () {
+          // given
+          const queryId = '26f6efcc-ce13-4b20-b6ea-5bebae6115af';
+          await knexAPI('catalog_queries').insert({
+            id: queryId,
+            sql_query: 'SELECT COUNT(*) FROM public.data_ref_academies',
+          });
+          await knexAPI('query_access').insert({
+            query_id: queryId,
+            user_id: userId,
+          });
+          const payload = {
+            queryId,
+            params: <any>[],
+          };
+
+          // when
+          const server = await createServer();
+          const response = await server.inject({
+            method: 'POST',
+            url: '/query',
+            payload,
+            headers: { authorization: headers },
+          });
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          expect(JSON.parse(response.payload)).to.deep.equal({
+            status: 'success',
+            data: [{ count: 33 }],
+            messages: [],
+          });
         });
 
-        // then
-        expect(response.statusCode).to.equal(200);
-        expect(JSON.parse(response.payload)).to.deep.equal({
-          status: 'success',
-          data: [{ count: 33 }],
-          messages: [],
-        });
       });
     });
 
     context('when "queryId" does not refer to an existing query', function () {
       it('should return a proper error response with status code 422', async function () {
         // given
-        const queryId = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+        const queryId = '26f6efcc-ce13-4b20-b6ea-5bebae6115af';
         const otherQueryId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
         await knexAPI('catalog_queries').insert({
           id: otherQueryId,

--- a/tests/integration/infrastructure/repositories/QueryAccessRepository_test.ts
+++ b/tests/integration/infrastructure/repositories/QueryAccessRepository_test.ts
@@ -1,0 +1,87 @@
+import { expect, knexAPI } from '../../../test-helper.js';
+import { queryAccessRepository } from '../../../../lib/infrastructure/QueryAccessRepository.js';
+import { NotFoundError } from '../../../../lib/domain/errors.js';
+import { QueryAccessModel } from '../../../../lib/domain/models/QueryAccess';
+
+describe('Integration | Repositories | QueryAccessRepository', function () {
+
+  afterEach(async function () {
+    await knexAPI('query_param_access').delete();
+    await knexAPI('query_access').delete();
+    await knexAPI('users').delete();
+    await knexAPI('catalog_query_params').delete();
+    await knexAPI('catalog_queries').delete();
+  });
+
+  context('when query access does not exist', function () {
+    it('should throw an error', async function () {
+      // given
+      const queryId = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+      const userId = '26f6efcc-ce13-4b20-b6ea-5bebae6115af';
+
+      // when
+      let error;
+      try {
+        await queryAccessRepository.get(queryId, userId);
+      } catch (e) {
+        error = e;
+      }
+
+      // then
+      expect(error).to.be.an.instanceOf(NotFoundError);
+      expect(error.message).to.equal('Query access not found');
+    });
+  });
+
+  context('when query access exists', function () {
+    it('should return the query access', async function() {
+      // given
+      const queryId = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+      const queryParamId = 1;
+      const userId = '26f6efcc-ce13-4b20-b6ea-5bebae6115af';
+
+      await knexAPI('catalog_queries').insert({
+        id: queryId,
+        sql_query: 'SELECT * FROM public.data_ref_academies LIMIT {{ limit}}',
+      });
+      await knexAPI('catalog_query_params').insert({
+        id: queryParamId,
+        catalog_query_id: queryId,
+        name: 'limit',
+        type: 'int',
+        mandatory: true,
+      });
+
+      await knexAPI('users').insert({
+        id: userId,
+        username: 'foo',
+        label: 'bar',
+        hashed_password: 'hashedPassword',
+      });
+
+      await knexAPI('query_access').insert({
+        query_id: queryId,
+        user_id: userId,
+      });
+      await knexAPI('query_param_access').insert({
+        query_param_id: queryParamId,
+        user_id: userId,
+        value: '10',
+      });
+      await knexAPI('query_param_access').insert({
+        query_param_id: queryParamId,
+        user_id: userId,
+        value: '20',
+      });
+
+      // when
+      const queryAccess = await queryAccessRepository.get(queryId, userId);
+
+      // then
+      expect(queryAccess).to.instanceOf(QueryAccessModel);
+      expect(queryAccess.paramsAccess).to.deep.equal({
+        limit: ['10', '20'],
+      });
+    });
+  });
+});

--- a/tests/unit/domain/commands/UserCommand_test.ts
+++ b/tests/unit/domain/commands/UserCommand_test.ts
@@ -7,6 +7,34 @@ import type { Result } from '../../../../lib/domain/models/Result.js';
 
 describe('Unit | Domain | UserCommand', function () {
   describe('buildFromPayload', function () {
+    context('when requesterId is invalid', function () {
+      const notValidRequesterId = [
+        '123',
+        123,
+        null,
+      ];
+
+      notValidRequesterId.forEach((requesterId) => {
+        it(`should return a failed CommandResult when requesterId is not a UUID : ${requesterId}`, function() {
+          // given
+          const validPayload = {
+            queryId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+            params: <any>[],
+          };
+
+          // when
+          const commandResult: Result<UserCommand> =
+            UserCommand.buildFromPayload(validPayload, requesterId);
+
+          // then
+          expect(commandResult.isSuccess).to.be.false;
+          expect(commandResult.errorMessages).to.have.members([
+            '"requesterId" is not a valid UUID',
+          ]);
+        });
+      });
+    });
+
     context('when payload is valid', function () {
       it('should return a successful CommandResult when params is an empty array', function () {
         // given
@@ -15,14 +43,17 @@ describe('Unit | Domain | UserCommand', function () {
           params: <any>[],
         };
 
+        const requesterId = 'c6eef19e-3de5-4b91-bcf0-70903af00551';
+
         // when
         const commandResult: Result<UserCommand> =
-          UserCommand.buildFromPayload(validPayload);
+          UserCommand.buildFromPayload(validPayload, requesterId);
 
         // then
         const expectedUserCommand = new UserCommand(
           'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
           [],
+          requesterId,
         );
         expect(commandResult.isSuccess).to.be.true;
         expect(commandResult.errorMessages).to.be.empty;
@@ -42,10 +73,11 @@ describe('Unit | Domain | UserCommand', function () {
             { name: 'floatArrayAttribute', value: [1.23, -45.6] },
           ],
         };
+        const requesterId = 'c6eef19e-3de5-4b91-bcf0-70903af00551';
 
         // when
         const commandResult: Result<UserCommand> =
-          UserCommand.buildFromPayload(validPayload);
+          UserCommand.buildFromPayload(validPayload, requesterId);
 
         // then
         const expectedParams: UserCommandParam[] = [];
@@ -68,6 +100,7 @@ describe('Unit | Domain | UserCommand', function () {
         const expectedUserCommand = new UserCommand(
           'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
           expectedParams,
+          requesterId,
         );
         expect(commandResult.isSuccess).to.be.true;
         expect(commandResult.errorMessages).to.be.empty;
@@ -88,10 +121,11 @@ describe('Unit | Domain | UserCommand', function () {
         it('should return a failed CommandResult', function () {
           // given
           const invalidPayload = 'coucou';
+          const requesterId = 'c6eef19e-3de5-4b91-bcf0-70903af00551';
 
           // when
           const commandResult: Result<UserCommand> =
-            UserCommand.buildFromPayload(invalidPayload);
+            UserCommand.buildFromPayload(invalidPayload, requesterId);
 
           // then
           expect(commandResult.isSuccess).to.be.false;
@@ -110,10 +144,11 @@ describe('Unit | Domain | UserCommand', function () {
             invalidAttributeA: 'a',
             invalidAttributeB: 'b',
           };
+          const requesterId = 'c6eef19e-3de5-4b91-bcf0-70903af00551';
 
           // when
           const commandResult: Result<UserCommand> =
-            UserCommand.buildFromPayload(invalidPayload);
+            UserCommand.buildFromPayload(invalidPayload, requesterId);
 
           // then
           expect(commandResult.isSuccess).to.be.false;
@@ -130,10 +165,11 @@ describe('Unit | Domain | UserCommand', function () {
           // given
           const invalidPayload = { ...validPayload };
           delete invalidPayload.queryId;
+          const requesterId = 'c6eef19e-3de5-4b91-bcf0-70903af00551';
 
           // when
           const commandResult: Result<UserCommand> =
-            UserCommand.buildFromPayload(invalidPayload);
+            UserCommand.buildFromPayload(invalidPayload, requesterId);
 
           // then
           expect(commandResult.isSuccess).to.be.false;
@@ -146,10 +182,11 @@ describe('Unit | Domain | UserCommand', function () {
         it('should return a failed CommandResult when "queryId" is not an UUID', function () {
           // given
           const invalidPayload = { ...validPayload, queryId: 'NOT AN UUID' };
+          const requesterId = 'c6eef19e-3de5-4b91-bcf0-70903af00551';
 
           // when
           const commandResult: Result<UserCommand> =
-            UserCommand.buildFromPayload(invalidPayload);
+            UserCommand.buildFromPayload(invalidPayload, requesterId);
 
           // then
           expect(commandResult.isSuccess).to.be.false;
@@ -165,10 +202,11 @@ describe('Unit | Domain | UserCommand', function () {
           // given
           const invalidPayload = { ...validPayload };
           delete invalidPayload.params;
+          const requesterId = 'c6eef19e-3de5-4b91-bcf0-70903af00551';
 
           // when
           const commandResult: Result<UserCommand> =
-            UserCommand.buildFromPayload(invalidPayload);
+            UserCommand.buildFromPayload(invalidPayload, requesterId);
 
           // then
           expect(commandResult.isSuccess).to.be.false;
@@ -181,10 +219,11 @@ describe('Unit | Domain | UserCommand', function () {
         it('should return a failed CommandResult when "params" is not an array', function () {
           // given
           const invalidPayload = { ...validPayload, params: 'invalidParams' };
+          const requesterId = 'c6eef19e-3de5-4b91-bcf0-70903af00551';
 
           // when
           const commandResult: Result<UserCommand> =
-            UserCommand.buildFromPayload(invalidPayload);
+            UserCommand.buildFromPayload(invalidPayload, requesterId);
 
           // then
           expect(commandResult.isSuccess).to.be.false;
@@ -212,10 +251,11 @@ describe('Unit | Domain | UserCommand', function () {
             },
           ];
           const invalidPayload = { ...validPayload, params: invalidParams };
+          const requesterId = 'c6eef19e-3de5-4b91-bcf0-70903af00551';
 
           // when
           const commandResult: Result<UserCommand> =
-            UserCommand.buildFromPayload(invalidPayload);
+            UserCommand.buildFromPayload(invalidPayload, requesterId);
 
           // then
           expect(commandResult.isSuccess).to.be.false;
@@ -240,10 +280,11 @@ describe('Unit | Domain | UserCommand', function () {
             },
           ];
           const invalidPayload = { ...validPayload, params: invalidParams };
+          const requesterId = 'c6eef19e-3de5-4b91-bcf0-70903af00551';
 
           // when
           const commandResult: Result<UserCommand> =
-            UserCommand.buildFromPayload(invalidPayload);
+            UserCommand.buildFromPayload(invalidPayload, requesterId);
 
           // then
           expect(commandResult.isSuccess).to.be.false;
@@ -287,10 +328,11 @@ describe('Unit | Domain | UserCommand', function () {
             },
           ];
           const invalidPayload = { ...validPayload, params: invalidParams };
+          const requesterId = 'c6eef19e-3de5-4b91-bcf0-70903af00551';
 
           // when
           const commandResult: Result<UserCommand> =
-            UserCommand.buildFromPayload(invalidPayload);
+            UserCommand.buildFromPayload(invalidPayload, requesterId);
 
           // then
           expect(commandResult.isSuccess).to.be.false;

--- a/tests/unit/domain/models/QueryAccess_test.ts
+++ b/tests/unit/domain/models/QueryAccess_test.ts
@@ -1,0 +1,61 @@
+import { expect } from 'chai';
+import { QueryAccess, QueryAccessModel } from '../../../../lib/domain/models/QueryAccess';
+import { UserCommandParam } from '../../../../lib/domain/commands/UserCommand';
+
+describe('Unit | Domain | Models | QueryAccess', function () {
+  describe('#areParamsValid', function () {
+    context('when userCommandParams is allowed', function () {
+      it('should return true', function () {
+        // given
+        const queryAccess: QueryAccess = {
+          id: ['123'],
+        }
+
+        const userCommandParams: UserCommandParam[] = [{
+          name: 'id',
+          value: '123',
+        }];
+
+        // when
+        const queryAccessModel = new QueryAccessModel(queryAccess);
+
+        // then
+        expect(queryAccessModel.areParamsValid(userCommandParams)).to.be.true;
+      });
+    });
+
+    context('when userCommandParams is empty', function () {
+      it('should return true', function () {
+        // given
+        const queryAccess: QueryAccess = {
+          id: ['123'],
+        }
+
+        const userCommandParams: UserCommandParam[] = [];
+
+        // when
+        const queryAccessModel = new QueryAccessModel(queryAccess);
+
+        // then
+        expect(queryAccessModel.areParamsValid(userCommandParams)).to.be.true;
+      });
+    });
+
+    context('when userCommandParams is not allowed', function () {
+      it('should return false', function () {
+        // given
+        const queryAccess: QueryAccess = {
+          id: ['123'],
+        }
+
+        const userCommandParams: UserCommandParam[] = [{ name: 'id', value: '456' }];
+
+        // when
+        const queryAccessModel = new QueryAccessModel(queryAccess);
+
+        // then
+        expect(queryAccessModel.areParamsValid(userCommandParams)).to.be.false;
+      });
+    });
+  });
+});

--- a/tests/unit/domain/usecases/ExecuteQueryUsecase_test.ts
+++ b/tests/unit/domain/usecases/ExecuteQueryUsecase_test.ts
@@ -6,11 +6,15 @@ import { DatamartRepository } from '../../../../lib/infrastructure/DatamartRepos
 import { DatamartResponse } from '../../../../lib/domain/models/DatamartResponse';
 import { DatamartQueryModel } from '../../../../lib/domain/models/DatamartQuery';
 import { expect } from '../../../test-helper';
-import { UserCommand } from '../../../../lib/domain/commands/UserCommand';
+import { UserCommand, UserCommandParam } from '../../../../lib/domain/commands/UserCommand';
+import { QueryAccessRepository } from '../../../../lib/infrastructure/QueryAccessRepository';
+import { type QueryAccess, QueryAccessModel } from '../../../../lib/domain/models/QueryAccess';
+import { NotFoundError } from '../../../../lib/domain/errors.js';
 
 describe('Unit | Domain | Usecases | ExecuteQueryUsecase', function () {
 
   describe('#executeQuery', function () {
+
     context('when query does not exist', function () {
       it('should return failed result', async function() {
         // given
@@ -26,16 +30,25 @@ describe('Unit | Domain | Usecases | ExecuteQueryUsecase', function () {
           }
         }
 
-        const datamartRepository: DatamartRepository = new DatamartRepositoryMock();
-        const queryRepository: CatalogQueryRepository = new QueryRepositoryMock();
+        class QueryAccessRepositoryMock implements QueryAccessRepository {
+          async get(_queryId: UUID, _userId: UUID): Promise<QueryAccessModel> {
+            return { } as QueryAccessModel;
+          }
+        }
 
-        const executeQueryUsecase = new ExecuteQueryUseCaseImpl(datamartRepository, queryRepository);
+        const datamartRepositoryMock = new DatamartRepositoryMock();
+        const queryRepositoryMock = new QueryRepositoryMock();
+        const queryAccessRepositoryMock = new QueryAccessRepositoryMock();
+
+        const executeQueryUsecase = new ExecuteQueryUseCaseImpl(datamartRepositoryMock, queryRepositoryMock, queryAccessRepositoryMock);
 
         const queryId = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+        const requesterId = 'c6eef19e-3de5-4b91-bcf0-70903af00551';
 
         const userCommand = {
           queryId,
-          params: []
+          params: [],
+          requesterId
         } as UserCommand;
 
         // when
@@ -49,11 +62,11 @@ describe('Unit | Domain | Usecases | ExecuteQueryUsecase', function () {
 
     context('when query exists', function () {
 
-      context('when params are invalid', function () {
+      context('when user is not allowed for this query', function () {
 
         it('should return failed result', async function() {
           // given
-          const expectedResult = ['cannot run requested query']
+          const expectedResult = ['User is not allowed to run this query']
           class DatamartRepositoryMock implements DatamartRepository {
             async find(_datamartQueryModel: DatamartQueryModel): Promise<DatamartResponse> {
               return { result: [] } as DatamartResponse;
@@ -66,16 +79,25 @@ describe('Unit | Domain | Usecases | ExecuteQueryUsecase', function () {
             }
           }
 
+          class QueryAccessRepositoryMock implements QueryAccessRepository {
+            async get(_queryId: UUID, _userId: UUID): Promise<QueryAccessModel> {
+              throw new NotFoundError('User not allowed to run this query');
+            }
+          }
+
           const datamartRepository: DatamartRepository = new DatamartRepositoryMock();
           const queryRepository: CatalogQueryRepository = new QueryRepositoryMock();
+          const queryAccessRepository: QueryAccessRepository = new QueryAccessRepositoryMock();
 
-          const executeQueryUsecase = new ExecuteQueryUseCaseImpl(datamartRepository, queryRepository);
+          const executeQueryUsecase = new ExecuteQueryUseCaseImpl(datamartRepository, queryRepository, queryAccessRepository);
 
           const queryId = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+          const requesterId = 'c6eef19e-3de5-4b91-bcf0-70903af00551';
 
           const userCommand = {
             queryId,
-            params: [{ name: 'foo', value: 'bar' }]
+            params: [],
+            requesterId,
           } as UserCommand;
 
           // when
@@ -87,41 +109,183 @@ describe('Unit | Domain | Usecases | ExecuteQueryUsecase', function () {
         });
       });
 
-      context('when params are valid', function () {
+      context('when user is allowed for this query', function () {
 
-        it('should return the query', async function() {
-          // given
-          const expectedResult = [{ test: Symbol('expected-result') }]
-          class DatamartRepositoryMock implements DatamartRepository {
-            async find(_datamartQueryModel: DatamartQueryModel): Promise<DatamartResponse> {
-              return { result: expectedResult } as DatamartResponse;
+        context('when userCommand params are unauthorized', function () {
+          it('should return failed result', async function() {
+            // given
+            const expectedError = ['No access to requested params']
+            class DatamartRepositoryMock implements DatamartRepository {
+              async find(_datamartQueryModel: DatamartQueryModel): Promise<DatamartResponse> {
+                return { result: [] } as DatamartResponse;
+              }
             }
-          }
 
-          class QueryRepositoryMock implements CatalogQueryRepository {
-            async find(_queryId: UUID): Promise<QueryCatalogItem> {
-              return { query: 'select * from tests', params: [] } as QueryCatalogItem;
+            class QueryRepositoryMock implements CatalogQueryRepository {
+              async find(_queryId: UUID): Promise<QueryCatalogItem> {
+                return { query: 'select * from tests', params: [] } as QueryCatalogItem;
+              }
             }
-          }
 
-          const datamartRepository: DatamartRepository = new DatamartRepositoryMock();
-          const queryRepository: CatalogQueryRepository = new QueryRepositoryMock();
 
-          const executeQueryUsecase = new ExecuteQueryUseCaseImpl(datamartRepository, queryRepository);
+            class QueryAccessModelMock extends QueryAccessModel {
+              constructor(queryAccess: QueryAccess) {
+                super(queryAccess);
+              }
 
-          const queryId = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+              override areParamsValid(_userCommandParams: UserCommandParam[]): boolean {
+                return false;
+              }
+            }
 
-          const userCommand = {
-            queryId,
-            params: []
-          } as UserCommand;
+            class QueryAccessRepositoryMock implements QueryAccessRepository {
+              async get(_queryId: UUID, _userId: UUID): Promise<QueryAccessModel> {
+                return new QueryAccessModelMock({} as QueryAccess);
+              }
+            }
 
-          // when
-          const result = await executeQueryUsecase.executeQuery(userCommand);
 
-          // then
-          expect(result.isSuccess).to.be.true;
-          expect(result.resultData.result).to.deep.equal(expectedResult);
+            const datamartRepository: DatamartRepository = new DatamartRepositoryMock();
+            const queryRepository: CatalogQueryRepository = new QueryRepositoryMock();
+            const queryAccessRepository: QueryAccessRepository = new QueryAccessRepositoryMock();
+
+            const executeQueryUsecase = new ExecuteQueryUseCaseImpl(datamartRepository, queryRepository, queryAccessRepository);
+
+            const queryId = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+            const requesterId = 'c6eef19e-3de5-4b91-bcf0-70903af00551';
+
+            const userCommand = {
+              queryId,
+              params: [],
+              requesterId
+            } as UserCommand;
+
+            // when
+            const result = await executeQueryUsecase.executeQuery(userCommand);
+
+            // then
+            expect(result.isFailure).to.be.true;
+            expect(result.errorMessages).to.deep.equal(expectedError);
+          });
+        });
+
+        context('when userCommand params are authorized', function () {
+
+          context('when params are invalid', function () {
+
+            it('should return failed result', async function() {
+              // given
+              const expectedResult = ['cannot run requested query']
+              class DatamartRepositoryMock implements DatamartRepository {
+                async find(_datamartQueryModel: DatamartQueryModel): Promise<DatamartResponse> {
+                  return { result: [] } as DatamartResponse;
+                }
+              }
+
+              class QueryRepositoryMock implements CatalogQueryRepository {
+                async find(_queryId: UUID): Promise<QueryCatalogItem> {
+                  return { query: 'select * from tests', params: [{ name: 'foo', type: ParamType.INT, mandatory: true }] } as QueryCatalogItem;
+                }
+              }
+
+              class QueryAccessModelMock extends QueryAccessModel {
+                constructor(queryAccess: QueryAccess) {
+                  super(queryAccess);
+                }
+
+                override areParamsValid(_userCommandParams: UserCommandParam[]): boolean {
+                  return true;
+                }
+              }
+
+              class QueryAccessRepositoryMock implements QueryAccessRepository {
+                async get(_queryId: UUID, _userId: UUID): Promise<QueryAccessModel> {
+                  return new QueryAccessModelMock({} as QueryAccess);
+                }
+              }
+
+
+              const datamartRepository: DatamartRepository = new DatamartRepositoryMock();
+              const queryRepository: CatalogQueryRepository = new QueryRepositoryMock();
+              const queryAccessRepository: QueryAccessRepository = new QueryAccessRepositoryMock();
+
+              const executeQueryUsecase = new ExecuteQueryUseCaseImpl(datamartRepository, queryRepository, queryAccessRepository);
+
+              const queryId = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+              const requesterId = 'c6eef19e-3de5-4b91-bcf0-70903af00551';
+
+              const userCommand = {
+                queryId,
+                params: [{ name: 'foo', value: 'bar' }],
+                requesterId,
+              } as UserCommand;
+
+              // when
+              const result = await executeQueryUsecase.executeQuery(userCommand);
+
+              // then
+              expect(result.isFailure).to.be.true;
+              expect(result.errorMessages).to.deep.equal(expectedResult);
+            });
+          });
+
+          context('when params are valid', function () {
+
+            it('should return the query', async function() {
+              // given
+              const expectedResult = [{ test: Symbol('expected-result') }]
+              class DatamartRepositoryMock implements DatamartRepository {
+                async find(_datamartQueryModel: DatamartQueryModel): Promise<DatamartResponse> {
+                  return { result: expectedResult } as DatamartResponse;
+                }
+              }
+
+              class QueryRepositoryMock implements CatalogQueryRepository {
+                async find(_queryId: UUID): Promise<QueryCatalogItem> {
+                  return { query: 'select * from tests', params: [{ name: 'foo', type: ParamType.STRING, mandatory: true }] } as QueryCatalogItem;
+                }
+              }
+
+              class QueryAccessModelMock extends QueryAccessModel {
+                constructor(queryAccess: QueryAccess) {
+                  super(queryAccess);
+                }
+
+                override areParamsValid(_userCommandParams: UserCommandParam[]): boolean {
+                  return true;
+                }
+              }
+
+              class QueryAccessRepositoryMock implements QueryAccessRepository {
+                async get(_queryId: UUID, _userId: UUID): Promise<QueryAccessModel> {
+                  return new QueryAccessModelMock({} as QueryAccess);
+                }
+              }
+
+
+              const datamartRepository: DatamartRepository = new DatamartRepositoryMock();
+              const queryRepository: CatalogQueryRepository = new QueryRepositoryMock();
+              const queryAccessRepository: QueryAccessRepository = new QueryAccessRepositoryMock();
+
+              const executeQueryUsecase = new ExecuteQueryUseCaseImpl(datamartRepository, queryRepository, queryAccessRepository);
+
+              const queryId = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+              const requesterId = 'c6eef19e-3de5-4b91-bcf0-70903af00551';
+
+              const userCommand = {
+                queryId,
+                params: [{ name: 'foo', value: 'bar' }],
+                requesterId
+              } as UserCommand;
+
+              // when
+              const result = await executeQueryUsecase.executeQuery(userCommand);
+
+              // then
+              expect(result.isSuccess).to.be.true;
+              expect(result.resultData.result).to.deep.equal(expectedResult);
+            });
+          });
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, n'importe quel utilisateur de l'API Data a accès à toutes les requêtes ainsi qu'à toutes les valeurs de paramètres possibles. Autrement dit, c'est open bar. 

## :robot: Proposition

Cette PR propose d'ajouter deux tables permettant de donner des droits.

Les deux tables sont : `query_access` et `query_param_access`. La première donnant les droits à une requête et la seconde à un paramètre et sa valeur. 

Après cette PR, par défaut, un nouveau compte sur l'API a accès à aucune requête.

Exemple : Si nous voulons donner l'accès à l'user A à la requête 123 et qui a le droit d'utiliser le paramètre `category_id`
 de la requête avec les valeurs `100` et `200`. 

- Nous ajoutons dans la table `query_access` l'userId de l'user A et le queryId de la requête
- Nous ajoutons dans la table `query_param_access` : 
	- Une première ligne pour la valeur 100 
	- Une seconde ligne pour la valeur 200

La gestion d'accès se fait dans l'use-case après avoir vérifié que la requête existait. 

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
1. Récupérer un token sur la RA 
```shell
ACCESS_TOKEN=$(curl -s -X POST https://pix-api-data-integration-pr66.osc-fr1.scalingo.io/token -H 'Content-Type: application/json' --data $'{ "username": "dev", "password": "LeMotDePasseQueL\'UtilisateurUtiliseraitDeSonPointDeVue" }' | jq -r .data.access_token)
```

### 1. L'user n'a pas accès à la requête 

Attendu : 422 Unprocessable Entity 

Requête
```shell
curl -v -X POST https://pix-api-data-integration-pr66.osc-fr1.scalingo.io/query -H 'Content-Type: application/json' -H "Authorization: Bearer $ACCESS_TOKEN" --data $'{ "queryId": "1b7291d4-ac51-46d2-97f1-f5f304100a29", "params": [] }'
```

Résultat 
```shell
< HTTP/1.1 422 Unprocessable Entity
< content-type: application/json; charset=utf-8
< vary: origin
< access-control-expose-headers: WWW-Authenticate,Server-Authorization
< cache-control: no-cache
< content-length: 73
< Date: Thu, 04 Jul 2024 15:21:59 GMT
< Connection: keep-alive
< Keep-Alive: timeout=5
<
* Connection #0 to host localhost left intact
{"status":"failure","messages":["User is not allowed to run this query"]
```

### 2. L'user a accès la requête 

#### a. et n'a pas accès à cette valeur de paramètre

Attendu : 422 Unprocessable Entity 

Requête :
```shell
curl -X -v POST https://pix-api-data-integration-pr66.osc-fr1.scalingo.io/query -H 'Content-Type: application/json' -H "Authorization: Bearer $ACCESS_TOKEN" --data $'{ "queryId": "b1e20492-8775-47f3-926d-3729ee2b836d", "params": [{"name":"id_list", "value": [1] }] }'
```

Résultat :
```shell
< HTTP/1.1 422 Unprocessable Entity
< content-type: application/json; charset=utf-8
< vary: origin
< access-control-expose-headers: WWW-Authenticate,Server-Authorization
< cache-control: no-cache
< content-length: 65
< Date: Thu, 04 Jul 2024 15:19:28 GMT
< Connection: keep-alive
< Keep-Alive: timeout=5
<
* Connection #0 to host localhost left intact
{"status":"failure","messages":["No access to requested params"]}
```

#### b. et a accès à cette valeur de paramètre

Attendu : 200 OK 

Requête : 
```shell
curl -X POST https://pix-api-data-integration-pr66.osc-fr1.scalingo.io/query -H 'Content-Type: application/json' -H "Authorization: Bearer $ACCESS_TOKEN" --data $'{ "queryId": "b1e20492-8775-47f3-926d-3729ee2b836d", "params": [{"name":"id_list", "value": [4] }] }'
```

Résultat 
```shell
{"status":"success","messages":[],"data":[{"id":4,"nom":"Orléans-Tours","region":"Centre-Val de Loire","departements":[18,28,36,37,41,45]}]}
```