### PR TITLE
[FEATURE] Ajouter une documentation de nos routes (PIX-13391).

### DIFF
--- a/lib/application/authentication/index.ts
+++ b/lib/application/authentication/index.ts
@@ -1,4 +1,6 @@
 import type { Server } from '@hapi/hapi';
+import Joi from 'joi';
+
 import { authenticate } from './authentication.js';
 
 const register = async function (server: Server) {
@@ -8,11 +10,18 @@ const register = async function (server: Server) {
       path: '/token',
       options: {
         auth: false,
+        validate: {
+          payload: Joi.object({
+            user: Joi.string().required(),
+            password: Joi.string().required(),
+          }).label('AuthenticationPayload'),
+        },
         handler: authenticate,
+        tags: ['api', 'authentication'],
       },
     },
   ]);
 };
 
 const name = 'authentication-api';
-export { register, name };
+export { name, register };

--- a/lib/application/query/index.ts
+++ b/lib/application/query/index.ts
@@ -1,4 +1,6 @@
 import type { Server } from '@hapi/hapi';
+import Joi from 'joi';
+
 import { execute } from './query.js';
 
 const register = async function (server: Server) {
@@ -7,11 +9,26 @@ const register = async function (server: Server) {
       method: 'POST',
       path: '/query',
       options: {
+        validate: {
+          payload: Joi.object({
+            queryId: Joi.string().uuid().required(),
+            params: Joi.array()
+              .items(
+                Joi.object({
+                  name: Joi.string().required(),
+                  value: Joi.any().required(),
+                }).label('QueryParameter'),
+              )
+              .required()
+              .label('QueryParameters'),
+          }).label('QueryPayload'),
+        },
         handler: execute,
+        tags: ['api', 'query'],
       },
     },
   ]);
 };
 
 const name = 'query-api';
-export { register, name };
+export { name, register };

--- a/lib/application/query/query.ts
+++ b/lib/application/query/query.ts
@@ -1,4 +1,5 @@
 import type { Request, ResponseObject, ResponseToolkit } from '@hapi/hapi';
+
 import { UserCommand } from '../../domain/commands/UserCommand.js';
 import type { Result } from '../../domain/models/Result.js';
 import { executeQueryUseCase } from '../../domain/usecases/ExecuteQueryUsecase.js';

--- a/lib/common/logger/Logger.ts
+++ b/lib/common/logger/Logger.ts
@@ -1,13 +1,15 @@
 import * as pino from 'pino';
-import * as pinoPretty from 'pino-pretty';
-import { config } from '../config.js';
 import { stdSerializers } from 'pino';
+import * as pinoPretty from 'pino-pretty';
+
+import { config } from '../config.js';
 
 const { logging } = config;
 
 let prettyPrint;
 if (logging.logForHumans) {
   const omitDay = 'HH:MM:ss';
+  // @ts-expect-error pino pretty does not have a named export
   prettyPrint = pinoPretty.default({
     sync: true,
     colorize: true,
@@ -16,6 +18,7 @@ if (logging.logForHumans) {
   });
 }
 
+// @ts-expect-error pino does not have a named export
 export const logger = pino.default(
   {
     level: logging.logLevel,

--- a/lib/common/logger/plugins/plugins.ts
+++ b/lib/common/logger/plugins/plugins.ts
@@ -1,5 +1,0 @@
-import Inert from '@hapi/inert';
-import Vision from '@hapi/vision';
-import * as pino from './pino.js';
-
-export const plugins = [Inert, Vision, pino];

--- a/lib/infrastructure/plugins/plugins.ts
+++ b/lib/infrastructure/plugins/plugins.ts
@@ -1,0 +1,7 @@
+import Inert from '@hapi/inert';
+import Vision from '@hapi/vision';
+
+import * as pino from '../../common/logger/plugins/pino.js';
+import { swaggerPlugin } from './swagger.js';
+
+export const plugins = [Inert, Vision, pino, swaggerPlugin];

--- a/lib/infrastructure/plugins/swagger.ts
+++ b/lib/infrastructure/plugins/swagger.ts
@@ -1,0 +1,13 @@
+import HapiSwagger from 'hapi-swagger';
+
+import packageJson from '../../../package.json' with { type: 'json' };
+
+export const swaggerPlugin = {
+  plugin: HapiSwagger,
+  options: {
+    info: {
+      title: 'API Data Documentation',
+      version: packageJson.version,
+    },
+  },
+};

--- a/lib/server.ts
+++ b/lib/server.ts
@@ -1,7 +1,8 @@
-import { routes } from './routes.js';
 import Hapi, { Server, ServerOptions } from '@hapi/hapi';
-import { plugins } from './common/logger/plugins/plugins.js';
+
 import { authentication } from './infrastructure/authentication.js';
+import { plugins } from './infrastructure/plugins/plugins.js';
+import { routes } from './routes.js';
 
 const createServer = async (): Promise<Server> => {
   const server = createBareServer();

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,8 @@
         "@hapi/vision": "^7.0.0",
         "bcrypt": "^5.1.0",
         "dotenv": "^16.3.1",
+        "hapi-swagger": "^17.2.1",
+        "joi": "^17.13.3",
         "jsonwebtoken": "^9.0.1",
         "knex": "^3.0.0",
         "lodash": "^4.17.21",
@@ -94,6 +96,94 @@
       },
       "peerDependencies": {
         "eslint": ">=8.56.0"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "11.6.4",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.6.4.tgz",
+      "integrity": "sha512-9K6xOqeevacvweLGik6LnZCb1fBtCOSIWQs8d096XGeqoLKC33UVMGz9+77Gw44KvbH4pKcQPWo4ZpxkXYj05w==",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "z-schema": "^5.0.1"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1322,6 +1412,11 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
+    },
     "node_modules/@mapbox/node-pre-gyp": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
@@ -1392,6 +1487,29 @@
       "funding": {
         "url": "https://opencollective.com/unts"
       }
+    },
+    "node_modules/@sideway/address": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/address/node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -1466,6 +1584,11 @@
       "integrity": "sha512-PatH4iOdyh3MyWtmHVFXLWCCIhUbopaltqddG9BzB+gMIzee2MJrvd+jouii9Z3wzQJruGWAm7WOMjgfG8hQlQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
     "node_modules/@types/jsonwebtoken": {
       "version": "9.0.6",
@@ -2189,6 +2312,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="
     },
     "node_modules/callsite": {
       "version": "1.0.0",
@@ -4099,6 +4227,47 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/hapi-swagger": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/hapi-swagger/-/hapi-swagger-17.2.1.tgz",
+      "integrity": "sha512-IaF3OHfYjzDuyi5EQgS0j0xB7sbAAD4DaTwexdhPYqEBI/J7GWMXFbftGObCIOeMVDufjoSBZWeaarEkNn6/ww==",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^11.1.0",
+        "@hapi/boom": "^10.0.1",
+        "@hapi/hoek": "^11.0.2",
+        "handlebars": "^4.7.8",
+        "http-status": "^1.7.3",
+        "swagger-parser": "^10.0.3",
+        "swagger-ui-dist": "^5.9.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@hapi/hapi": ">=20.x.x",
+        "joi": "17.x"
+      }
+    },
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -4161,6 +4330,14 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/http-status": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/http-status/-/http-status-1.7.4.tgz",
+      "integrity": "sha512-c2qSwNtTlHVYAhMj9JpGdyo0No/+DiKXCJ9pHtZ2Yf3QmPnBIytKSRT7BuyIiQ7icXLynavGmxUqkOjSrAuMuA==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
@@ -4460,6 +4637,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/joi": {
+      "version": "17.13.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "dependencies": {
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
+    "node_modules/joi/node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    },
+    "node_modules/joi/node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "node_modules/joycon": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -4725,7 +4927,6 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
@@ -4744,7 +4945,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.isinteger": {
@@ -5284,6 +5484,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+    },
     "node_modules/nise": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/nise/-/nise-6.0.0.tgz",
@@ -5516,6 +5721,12 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "peer": true
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -6711,6 +6922,14 @@
         "atomic-sleep": "^1.0.0"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
@@ -6865,6 +7084,22 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
+      "dependencies": {
+        "@apidevtools/swagger-parser": "10.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.17.14",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.17.14.tgz",
+      "integrity": "sha512-CVbSfaLpstV65OnSjbXfVd6Sta3q3F7Cj/yYuvHMp1P90LztOLs6PfUnKEVAeiIVQt9u2SaPwv0LiH/OyMjHRw=="
     },
     "node_modules/synckit": {
       "version": "0.8.8",
@@ -7068,6 +7303,18 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uglify-js": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.18.0.tgz",
+      "integrity": "sha512-SyVVbcNBCk0dzr9XL/R/ySrmYf0s372K6/hFklzgcp2lBFyXtw4I7BOdDjlLhE1aVqaI/SHWXWmYdlZxuyF38A==",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/undefsafe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
@@ -7139,6 +7386,14 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -7189,6 +7444,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
     },
     "node_modules/workerpool": {
       "version": "6.5.1",
@@ -7382,6 +7642,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/z-schema": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      },
+      "bin": {
+        "z-schema": "bin/z-schema"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "commander": "^9.4.1"
+      }
+    },
+    "node_modules/z-schema/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "@hapi/vision": "^7.0.0",
     "bcrypt": "^5.1.0",
     "dotenv": "^16.3.1",
+    "hapi-swagger": "^17.2.1",
+    "joi": "^17.13.3",
     "jsonwebtoken": "^9.0.1",
     "knex": "^3.0.0",
     "lodash": "^4.17.21",

--- a/scripts/_template.ts
+++ b/scripts/_template.ts
@@ -3,11 +3,11 @@ dotenv.config();
 import perf_hooks from 'perf_hooks';
 import * as url from 'url';
 const { performance } = perf_hooks;
-import { logger } from '../lib/common/logger/Logger';
 import {
-  knexAPI,
   disconnect,
+  knexAPI,
 } from '../lib/common/db/knex-database-connections.js';
+import { logger } from '../lib/common/logger/Logger.js';
 /* If you use command line args, uncomment me
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';

--- a/scripts/prod/add-user.ts
+++ b/scripts/prod/add-user.ts
@@ -3,14 +3,15 @@ dotenv.config();
 import perf_hooks from 'perf_hooks';
 import * as url from 'url';
 const { performance } = perf_hooks;
-import { logger } from '../../lib/common/logger/Logger';
-import { encryptionService } from '../../lib/infrastructure/utils/EncryptionService';
-import {
-  knexAPI,
-  disconnect,
-} from '../../lib/common/db/knex-database-connections.js';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
+
+import {
+  disconnect,
+  knexAPI,
+} from '../../lib/common/db/knex-database-connections.js';
+import { logger } from '../../lib/common/logger/Logger.js';
+import { encryptionService } from '../../lib/infrastructure/utils/EncryptionService.js';
 const parseMe = yargs(hideBin(process.argv))
   .option('username', {
     type: 'string',

--- a/tests/acceptance/application/query_test.ts
+++ b/tests/acceptance/application/query_test.ts
@@ -47,11 +47,9 @@ describe('Acceptance | query', function () {
       // then
       expect(response.statusCode).to.equal(400);
       expect(JSON.parse(response.payload)).to.deep.equal({
-        status: 'failure',
-        messages: [
-          'unknown attribute: "queryIdddddddd"',
-          '"queryId" is mandatory',
-        ],
+        statusCode: 400,
+        error: 'Bad Request',
+        message: 'Invalid request payload input',
       });
     });
   });
@@ -136,7 +134,7 @@ describe('Acceptance | query', function () {
       it('should return a proper error response with status code 422', async function () {
         // given
         const queryId = '26f6efcc-ce13-4b20-b6ea-5bebae6115af';
-        const otherQueryId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+        const otherQueryId = '11a1aaaa-aa11-1a11-a1aa-1aaaaa1111aa';
         await knexAPI('catalog_queries').insert({
           id: otherQueryId,
           sql_query: 'SELECT COUNT(*) FROM public.data_ref_academies',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@tsconfig/node-lts-strictest-esm/tsconfig.json",
   "compilerOptions": {
-    "moduleResolution": "node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "lib": ["es2023"],
     "outDir": "build",
     "rootDir": "./",
@@ -12,6 +13,7 @@
     "ignoreDeprecations": "5.0",
     "esModuleInterop": true,
     "exactOptionalPropertyTypes": false,
+    "resolveJsonModule": true,
   },
   "include": ["**/*.ts", "**/*.js" ],
   "exclude": ["node_modules", "build", "tests"]


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, l'API n'est pas documenté alors qu'elle a vocation a être utilisé par des partenaires.

## :robot: Proposition
Ajouter le plugin hapi-swagger, qui permet de générer un swagger grâce à des schémas Joi et ajoute la route `/documentation`.

Ajout des schémas des payloads des requêtes

## :rainbow: Remarques
RAF : ajouter des schémas des retours 

La config TS est passé en `nodenext`, pour pouvoir gérer le json.

Des `@ts-expect-error` ont été ajouté car le passage en `nodenext` prevenait de l'erreur `TS2349` dont on ne peut pas faire grand chose. 

## :100: Pour tester
Se rendre sur [`/documentation`](https://pix-api-data-integration-pr6.osc-fr1.scalingo.io/documentation)
