### PR TITLE
[BUGFIX] Réparer la récupération de token 

### DIFF
--- a/lib/application/authentication/index.ts
+++ b/lib/application/authentication/index.ts
@@ -12,7 +12,7 @@ const register = async function (server: Server) {
         auth: false,
         validate: {
           payload: Joi.object({
-            user: Joi.string().required(),
+            username: Joi.string().required(),
             password: Joi.string().required(),
           }).label('AuthenticationPayload'),
         },

--- a/tests/acceptance/application/authentication_test.ts
+++ b/tests/acceptance/application/authentication_test.ts
@@ -26,11 +26,9 @@ describe('Acceptance | authentication', function () {
       // then
       expect(response.statusCode).to.equal(400);
       expect(JSON.parse(response.payload)).to.deep.equal({
-        status: 'failure',
-        messages: [
-          'unknown attribute: "usernameeeeeeeeuh"',
-          '"username" is mandatory',
-        ],
+        error: "Bad Request",
+        message: "Invalid request payload input",
+        statusCode: 400
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Une erreur a été commise le schéma Joi fait référence à `user` au lieu de `username` et cela est passé car la CI a été désactivé suite au repush du repo (pour retirer le fait que c'était un fork de nestjs)

## :robot: Proposition
Corriger 

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
