### PR TITLE
[TECH] Simplifier les tests unitaires de l'use-case ExecuteQuery

### DIFF
--- a/lib/domain/usecases/ExecuteQueryUsecase.ts
+++ b/lib/domain/usecases/ExecuteQueryUsecase.ts
@@ -54,7 +54,7 @@ export class ExecuteQueryUseCaseImpl implements ExecuteQueryUseCase {
         return Result.failure(['No access to requested params']);
       }
     }
-    catch (e) {
+    catch {
       return Result.failure(['User is not allowed to run this query']);
     }
 

--- a/lib/infrastructure/utils/JSONWebTokenService.ts
+++ b/lib/infrastructure/utils/JSONWebTokenService.ts
@@ -39,7 +39,7 @@ class JSONWebTokenImpl implements JSONWebTokenService {
       };
       return { user_id: decodedToken.user_id } as AuthenticationToken;
     }
-    catch (err) {
+    catch {
       return null;
     }
   }

--- a/tests/unit/domain/usecases/ExecuteQueryUsecase_test.ts
+++ b/tests/unit/domain/usecases/ExecuteQueryUsecase_test.ts
@@ -1,45 +1,23 @@
-import type { UUID } from 'node:crypto';
-import type { CatalogQueryRepository } from '../../../../lib/infrastructure/CatalogQueryRepository';
-import type { QueryCatalogItem } from '../../../../lib/domain/models/QueryCatalogItem';
-import { ParamType } from '../../../../lib/domain/models/QueryCatalogItem';
-import { ExecuteQueryUseCaseImpl } from '../../../../lib/domain/usecases/ExecuteQueryUsecase';
-import type { DatamartRepository } from '../../../../lib/infrastructure/DatamartRepository';
-import type { DatamartResponse } from '../../../../lib/domain/models/DatamartResponse';
-import type { DatamartQueryModel } from '../../../../lib/domain/models/DatamartQuery';
-import { expect } from '../../../test-helper';
-import type { UserCommand, UserCommandParam } from '../../../../lib/domain/commands/UserCommand';
-import type { QueryAccessRepository } from '../../../../lib/infrastructure/QueryAccessRepository';
-import { type QueryAccess, QueryAccessModel } from '../../../../lib/domain/models/QueryAccess';
+import { catalogQueryRepository } from '../../../../lib/infrastructure/CatalogQueryRepository.js';
+import { ParamType } from '../../../../lib/domain/models/QueryCatalogItem.js';
+import { ExecuteQueryUseCaseImpl } from '../../../../lib/domain/usecases/ExecuteQueryUsecase.js';
+import { datamartRepository } from '../../../../lib/infrastructure/DatamartRepository.js';
+import { expect, sinon } from '../../../test-helper.js';
+import type { UserCommand, UserCommandParam } from '../../../../lib/domain/commands/UserCommand.js';
+import { queryAccessRepository } from '../../../../lib/infrastructure/QueryAccessRepository.js';
+import { type QueryAccess, QueryAccessModel } from '../../../../lib/domain/models/QueryAccess.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
+import type { DatamartResponse } from '../../../../lib/domain/models/DatamartResponse.js';
 
 describe('Unit | Domain | Usecases | ExecuteQueryUsecase', function () {
   describe('#executeQuery', function () {
     context('when query does not exist', function () {
       it('should return failed result', async function () {
         // given
-        class DatamartRepositoryMock implements DatamartRepository {
-          async find(_datamartQueryModel: DatamartQueryModel): Promise<DatamartResponse> {
-            return { } as DatamartResponse;
-          }
-        }
 
-        class QueryRepositoryMock implements CatalogQueryRepository {
-          async find(_queryId: UUID): Promise<QueryCatalogItem> {
-            return { query: undefined, params: [] } as QueryCatalogItem;
-          }
-        }
+        sinon.stub(catalogQueryRepository, 'find').resolves({ query: undefined, params: [] });
 
-        class QueryAccessRepositoryMock implements QueryAccessRepository {
-          async get(_queryId: UUID, _userId: UUID): Promise<QueryAccessModel> {
-            return { } as QueryAccessModel;
-          }
-        }
-
-        const datamartRepositoryMock = new DatamartRepositoryMock();
-        const queryRepositoryMock = new QueryRepositoryMock();
-        const queryAccessRepositoryMock = new QueryAccessRepositoryMock();
-
-        const executeQueryUsecase = new ExecuteQueryUseCaseImpl(datamartRepositoryMock, queryRepositoryMock, queryAccessRepositoryMock);
+        const executeQueryUsecase = new ExecuteQueryUseCaseImpl(datamartRepository, catalogQueryRepository, queryAccessRepository);
 
         const queryId = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
         const requesterId = 'c6eef19e-3de5-4b91-bcf0-70903af00551';
@@ -64,29 +42,11 @@ describe('Unit | Domain | Usecases | ExecuteQueryUsecase', function () {
         it('should return failed result', async function () {
           // given
           const expectedResult = ['User is not allowed to run this query'];
-          class DatamartRepositoryMock implements DatamartRepository {
-            async find(_datamartQueryModel: DatamartQueryModel): Promise<DatamartResponse> {
-              return { result: [] } as DatamartResponse;
-            }
-          }
 
-          class QueryRepositoryMock implements CatalogQueryRepository {
-            async find(_queryId: UUID): Promise<QueryCatalogItem> {
-              return { query: 'select * from tests', params: [{ name: 'foo', type: ParamType.INT, mandatory: true }] } as QueryCatalogItem;
-            }
-          }
+          sinon.stub(catalogQueryRepository, 'find').resolves({ query: 'select * from tests', params: [{ name: 'foo', type: ParamType.INT, mandatory: true }] });
+          sinon.stub(queryAccessRepository, 'get').throws(new NotFoundError('User not allowed to run this query'));
 
-          class QueryAccessRepositoryMock implements QueryAccessRepository {
-            async get(_queryId: UUID, _userId: UUID): Promise<QueryAccessModel> {
-              throw new NotFoundError('User not allowed to run this query');
-            }
-          }
-
-          const datamartRepository: DatamartRepository = new DatamartRepositoryMock();
-          const queryRepository: CatalogQueryRepository = new QueryRepositoryMock();
-          const queryAccessRepository: QueryAccessRepository = new QueryAccessRepositoryMock();
-
-          const executeQueryUsecase = new ExecuteQueryUseCaseImpl(datamartRepository, queryRepository, queryAccessRepository);
+          const executeQueryUsecase = new ExecuteQueryUseCaseImpl(datamartRepository, catalogQueryRepository, queryAccessRepository);
 
           const queryId = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
           const requesterId = 'c6eef19e-3de5-4b91-bcf0-70903af00551';
@@ -110,18 +70,17 @@ describe('Unit | Domain | Usecases | ExecuteQueryUsecase', function () {
         context('when userCommand params are unauthorized', function () {
           it('should return failed result', async function () {
             // given
-            const expectedError = ['No access to requested params'];
-            class DatamartRepositoryMock implements DatamartRepository {
-              async find(_datamartQueryModel: DatamartQueryModel): Promise<DatamartResponse> {
-                return { result: [] } as DatamartResponse;
-              }
-            }
+            const queryId = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+            const requesterId = 'c6eef19e-3de5-4b91-bcf0-70903af00551';
 
-            class QueryRepositoryMock implements CatalogQueryRepository {
-              async find(_queryId: UUID): Promise<QueryCatalogItem> {
-                return { query: 'select * from tests', params: [] } as QueryCatalogItem;
-              }
-            }
+            const userCommand = {
+              queryId,
+              params: [],
+              requesterId,
+            } as UserCommand;
+
+            const expectedError = ['No access to requested params'];
+            sinon.stub(catalogQueryRepository, 'find').withArgs(queryId).resolves({ query: 'select * from tests', params: [] });
 
             class QueryAccessModelMock extends QueryAccessModel {
               constructor(queryAccess: QueryAccess) {
@@ -133,26 +92,10 @@ describe('Unit | Domain | Usecases | ExecuteQueryUsecase', function () {
               }
             }
 
-            class QueryAccessRepositoryMock implements QueryAccessRepository {
-              async get(_queryId: UUID, _userId: UUID): Promise<QueryAccessModel> {
-                return new QueryAccessModelMock({} as QueryAccess);
-              }
-            }
+            sinon.stub(queryAccessRepository, 'get').withArgs(queryId, requesterId).resolves(new QueryAccessModelMock({} as QueryAccess));
+            sinon.stub(datamartRepository, 'find').resolves({ result: [] });
 
-            const datamartRepository: DatamartRepository = new DatamartRepositoryMock();
-            const queryRepository: CatalogQueryRepository = new QueryRepositoryMock();
-            const queryAccessRepository: QueryAccessRepository = new QueryAccessRepositoryMock();
-
-            const executeQueryUsecase = new ExecuteQueryUseCaseImpl(datamartRepository, queryRepository, queryAccessRepository);
-
-            const queryId = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
-            const requesterId = 'c6eef19e-3de5-4b91-bcf0-70903af00551';
-
-            const userCommand = {
-              queryId,
-              params: [],
-              requesterId,
-            } as UserCommand;
+            const executeQueryUsecase = new ExecuteQueryUseCaseImpl(datamartRepository, catalogQueryRepository, queryAccessRepository);
 
             // when
             const result = await executeQueryUsecase.executeQuery(userCommand);
@@ -168,17 +111,14 @@ describe('Unit | Domain | Usecases | ExecuteQueryUsecase', function () {
             it('should return failed result', async function () {
               // given
               const expectedResult = ['cannot run requested query'];
-              class DatamartRepositoryMock implements DatamartRepository {
-                async find(_datamartQueryModel: DatamartQueryModel): Promise<DatamartResponse> {
-                  return { result: [] } as DatamartResponse;
-                }
-              }
+              const queryId = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+              const requesterId = 'c6eef19e-3de5-4b91-bcf0-70903af00551';
 
-              class QueryRepositoryMock implements CatalogQueryRepository {
-                async find(_queryId: UUID): Promise<QueryCatalogItem> {
-                  return { query: 'select * from tests', params: [{ name: 'foo', type: ParamType.INT, mandatory: true }] } as QueryCatalogItem;
-                }
-              }
+              const userCommand = {
+                queryId,
+                params: [{ name: 'foo', value: 'bar' }],
+                requesterId,
+              } as UserCommand;
 
               class QueryAccessModelMock extends QueryAccessModel {
                 constructor(queryAccess: QueryAccess) {
@@ -190,26 +130,12 @@ describe('Unit | Domain | Usecases | ExecuteQueryUsecase', function () {
                 }
               }
 
-              class QueryAccessRepositoryMock implements QueryAccessRepository {
-                async get(_queryId: UUID, _userId: UUID): Promise<QueryAccessModel> {
-                  return new QueryAccessModelMock({} as QueryAccess);
-                }
-              }
+              const queryCatalogItem = { query: 'select * from tests', params: [{ name: 'foo', type: ParamType.INT, mandatory: true }] };
+              sinon.stub(catalogQueryRepository, 'find').resolves(queryCatalogItem);
+              sinon.stub(queryAccessRepository, 'get').withArgs(queryId, requesterId).resolves(new QueryAccessModelMock({} as QueryAccess));
+              sinon.stub(datamartRepository, 'find').resolves({} as DatamartResponse);
 
-              const datamartRepository: DatamartRepository = new DatamartRepositoryMock();
-              const queryRepository: CatalogQueryRepository = new QueryRepositoryMock();
-              const queryAccessRepository: QueryAccessRepository = new QueryAccessRepositoryMock();
-
-              const executeQueryUsecase = new ExecuteQueryUseCaseImpl(datamartRepository, queryRepository, queryAccessRepository);
-
-              const queryId = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
-              const requesterId = 'c6eef19e-3de5-4b91-bcf0-70903af00551';
-
-              const userCommand = {
-                queryId,
-                params: [{ name: 'foo', value: 'bar' }],
-                requesterId,
-              } as UserCommand;
+              const executeQueryUsecase = new ExecuteQueryUseCaseImpl(datamartRepository, catalogQueryRepository, queryAccessRepository);
 
               // when
               const result = await executeQueryUsecase.executeQuery(userCommand);
@@ -224,17 +150,15 @@ describe('Unit | Domain | Usecases | ExecuteQueryUsecase', function () {
             it('should return the query', async function () {
               // given
               const expectedResult = [{ test: Symbol('expected-result') }];
-              class DatamartRepositoryMock implements DatamartRepository {
-                async find(_datamartQueryModel: DatamartQueryModel): Promise<DatamartResponse> {
-                  return { result: expectedResult } as DatamartResponse;
-                }
-              }
 
-              class QueryRepositoryMock implements CatalogQueryRepository {
-                async find(_queryId: UUID): Promise<QueryCatalogItem> {
-                  return { query: 'select * from tests', params: [{ name: 'foo', type: ParamType.STRING, mandatory: true }] } as QueryCatalogItem;
-                }
-              }
+              const queryId = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+              const requesterId = 'c6eef19e-3de5-4b91-bcf0-70903af00551';
+
+              const userCommand = {
+                queryId,
+                params: [{ name: 'foo', value: 'bar' }],
+                requesterId,
+              } as UserCommand;
 
               class QueryAccessModelMock extends QueryAccessModel {
                 constructor(queryAccess: QueryAccess) {
@@ -246,26 +170,12 @@ describe('Unit | Domain | Usecases | ExecuteQueryUsecase', function () {
                 }
               }
 
-              class QueryAccessRepositoryMock implements QueryAccessRepository {
-                async get(_queryId: UUID, _userId: UUID): Promise<QueryAccessModel> {
-                  return new QueryAccessModelMock({} as QueryAccess);
-                }
-              }
+              const queryCatalogItem = { query: 'select * from tests', params: [{ name: 'foo', type: ParamType.STRING, mandatory: true }] };
+              sinon.stub(catalogQueryRepository, 'find').resolves(queryCatalogItem);
+              sinon.stub(queryAccessRepository, 'get').withArgs(queryId, requesterId).resolves(new QueryAccessModelMock({} as QueryAccess));
+              sinon.stub(datamartRepository, 'find').resolves({ result: expectedResult } as DatamartResponse);
 
-              const datamartRepository: DatamartRepository = new DatamartRepositoryMock();
-              const queryRepository: CatalogQueryRepository = new QueryRepositoryMock();
-              const queryAccessRepository: QueryAccessRepository = new QueryAccessRepositoryMock();
-
-              const executeQueryUsecase = new ExecuteQueryUseCaseImpl(datamartRepository, queryRepository, queryAccessRepository);
-
-              const queryId = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
-              const requesterId = 'c6eef19e-3de5-4b91-bcf0-70903af00551';
-
-              const userCommand = {
-                queryId,
-                params: [{ name: 'foo', value: 'bar' }],
-                requesterId,
-              } as UserCommand;
+              const executeQueryUsecase = new ExecuteQueryUseCaseImpl(datamartRepository, catalogQueryRepository, queryAccessRepository);
 
               // when
               const result = await executeQueryUsecase.executeQuery(userCommand);


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, les tests sont écrits en étendant toutes les class pour refaire une implémentation. C'est fastidieux et compliqué à relire.

## :robot: Proposition
Utiliser sinon à la place qui a aussi l'avantage de pouvoir tester les arguments envoyés aux différentes fonctions.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
