### PR TITLE
[FEATURE] Streamer les réponses des requêtes (PIX-14215.

### DIFF
--- a/.depcheckrc
+++ b/.depcheckrc
@@ -1,1 +1,1 @@
-ignores: ["@tsconfig/node-lts-strictest-esm"]
+ignores: ["@tsconfig/node-lts-strictest-esm", "pg-query-stream"]

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,0 @@
-build
-node_modules
-data
-.circleci

--- a/lib/application/APIResponse.ts
+++ b/lib/application/APIResponse.ts
@@ -1,3 +1,4 @@
+import { Readable } from 'node:stream';
 import { config } from '../common/config.js';
 import { logger } from '../common/logger/Logger.js';
 
@@ -24,6 +25,30 @@ export class APIResponse<TYPE_DATA> {
   static success<TYPE_DATA>(data: TYPE_DATA): APIResponse<TYPE_DATA> {
     return new APIResponse<TYPE_DATA>(APIResponseStatuses.SUCCESS, [], data);
   }
+
+  static successStream(data: Readable): Readable {
+    const stream = new Readable({
+      read() {},
+    });
+    stream.push('{"status":"success","data":[');
+
+    let isFirstLine = true;
+
+    data.on('data', (row) => {
+      if (!isFirstLine) {
+        stream.push(',');
+      }
+      isFirstLine = false;
+      stream.push(JSON.stringify(row));
+    });
+
+    data.on('end', () => {
+      stream.push('], "messages": []}');
+      stream.push(null);
+    });
+
+    return stream;
+  };
 
   static authenticationSuccess(accessToken: string): APIResponse<{
     access_token: string;

--- a/lib/application/query/query.ts
+++ b/lib/application/query/query.ts
@@ -29,6 +29,6 @@ export async function execute(
   }
 
   return h.response(
-    APIResponse.success(queryExecutionResult.resultData.result),
-  );
+    APIResponse.successStream(queryExecutionResult.resultData.result),
+  ).type('application.json');
 }

--- a/lib/domain/models/DatamartResponse.ts
+++ b/lib/domain/models/DatamartResponse.ts
@@ -1,3 +1,5 @@
+import type { Readable } from 'node:stream';
+
 export interface DatamartResponse {
-  result: object[];
+  result: Readable;
 }

--- a/lib/domain/usecases/ExecuteQueryUsecase.ts
+++ b/lib/domain/usecases/ExecuteQueryUsecase.ts
@@ -68,7 +68,7 @@ export class ExecuteQueryUseCaseImpl implements ExecuteQueryUseCase {
     }
 
     const datamartResponse: DatamartResponse
-      = await this.datamartRepository.find(datamartQueryModel);
+      = this.datamartRepository.find(datamartQueryModel);
     return Result.success(datamartResponse);
   }
 }

--- a/lib/infrastructure/DatamartRepository.ts
+++ b/lib/infrastructure/DatamartRepository.ts
@@ -4,17 +4,17 @@ import type { DatamartQueryModel } from '../domain/models/DatamartQuery.js';
 import { QueryBuilder } from './builder/QueryBuilder.js';
 
 export interface DatamartRepository {
-  find: (datamartQueryModel: DatamartQueryModel) => Promise<DatamartResponse>;
+  find: (datamartQueryModel: DatamartQueryModel) => DatamartResponse;
 }
 class DatamartRepositoryImpl implements DatamartRepository {
-  async find(
+  find(
     datamartQueryModel: DatamartQueryModel,
-  ): Promise<DatamartResponse> {
+  ): DatamartResponse {
     const queryBuilder = new QueryBuilder(datamartQueryModel);
     const knexQuery = queryBuilder.build();
-    const result = await knexDatamart.raw(knexQuery.query, knexQuery.params);
+    const stream = knexDatamart.raw(knexQuery.query, knexQuery.params).stream();
     return {
-      result: result.rows,
+      result: stream,
     } as DatamartResponse;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "nodemon": "^3.0.1",
         "papaparse": "^5.4.1",
         "pg": "^8.11.1",
+        "pg-query-stream": "^4.6.0",
         "pino": "^9.0.0",
         "pino-pretty": "^11.0.0",
         "yargs": "^17.7.2"
@@ -6758,6 +6759,14 @@
       "integrity": "sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==",
       "license": "MIT"
     },
+    "node_modules/pg-cursor": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.11.0.tgz",
+      "integrity": "sha512-TLCOCtu+rqMarzjUi+/Ffc2DV5ZqO/27y5GqnK9Z3w51rWXMwC8FcO96Uf9/ORo5o+qRXEVJxM9Ts3K2K31MLg==",
+      "peerDependencies": {
+        "pg": "^8"
+      }
+    },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -6781,6 +6790,17 @@
       "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.1.tgz",
       "integrity": "sha512-jPIlvgoD63hrEuihvIg+tJhoGjUsLPn6poJY9N5CnlPd91c2T18T/9zBtLxZSb1EhYxBRoZJtzScCaWlYLtktg==",
       "license": "MIT"
+    },
+    "node_modules/pg-query-stream": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-4.6.0.tgz",
+      "integrity": "sha512-sg2Hewe6ge6osEY07zGu7Z8djrsQBvyiTy5ZjQffoSatEgnNNVsV3EWDm9Px/8R9oaAL1YnfnP8AXPMmfzujZg==",
+      "dependencies": {
+        "pg-cursor": "^2.11.0"
+      },
+      "peerDependencies": {
+        "pg": "^8"
+      }
     },
     "node_modules/pg-types": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "nodemon": "^3.0.1",
     "papaparse": "^5.4.1",
     "pg": "^8.11.1",
+    "pg-query-stream": "^4.6.0",
     "pino": "^9.0.0",
     "pino-pretty": "^11.0.0",
     "yargs": "^17.7.2"

--- a/tests/acceptance/application/query_test.ts
+++ b/tests/acceptance/application/query_test.ts
@@ -63,7 +63,7 @@ describe('Acceptance | query', function () {
           const queryId = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
           await knexAPI('catalog_queries').insert({
             id: queryId,
-            sql_query: 'SELECT COUNT(*) FROM public.data_ref_academies',
+            sql_query: 'SELECT COUNT(*) FROM public.data_ref_academies UNION SELECT 1;',
           });
           await knexAPI('query_access').insert({
             query_id: queryId,
@@ -87,7 +87,7 @@ describe('Acceptance | query', function () {
           expect(response.statusCode).to.equal(200);
           expect(JSON.parse(response.payload)).to.deep.equal({
             status: 'success',
-            data: [{ count: 33 }],
+            data: [{ count: 1 }, { count: 33 }],
             messages: [],
           });
         });

--- a/tests/unit/domain/usecases/ExecuteQueryUsecase_test.ts
+++ b/tests/unit/domain/usecases/ExecuteQueryUsecase_test.ts
@@ -1,3 +1,4 @@
+import { Readable } from 'node:stream';
 import { catalogQueryRepository } from '../../../../lib/infrastructure/CatalogQueryRepository.js';
 import { ParamType } from '../../../../lib/domain/models/QueryCatalogItem.js';
 import { ExecuteQueryUseCaseImpl } from '../../../../lib/domain/usecases/ExecuteQueryUsecase.js';
@@ -149,7 +150,10 @@ describe('Unit | Domain | Usecases | ExecuteQueryUsecase', function () {
           context('when params are valid', function () {
             it('should return the query', async function () {
               // given
-              const expectedResult = [{ test: Symbol('expected-result') }];
+              const expectedResult = 'expected-result';
+              const readable = new Readable();
+              readable.push(expectedResult);
+              readable.push(null);
 
               const queryId = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
               const requesterId = 'c6eef19e-3de5-4b91-bcf0-70903af00551';
@@ -173,7 +177,7 @@ describe('Unit | Domain | Usecases | ExecuteQueryUsecase', function () {
               const queryCatalogItem = { query: 'select * from tests', params: [{ name: 'foo', type: ParamType.STRING, mandatory: true }] };
               sinon.stub(catalogQueryRepository, 'find').resolves(queryCatalogItem);
               sinon.stub(queryAccessRepository, 'get').withArgs(queryId, requesterId).resolves(new QueryAccessModelMock({} as QueryAccess));
-              sinon.stub(datamartRepository, 'find').resolves({ result: expectedResult } as DatamartResponse);
+              sinon.stub(datamartRepository, 'find').returns({ result: readable } as DatamartResponse);
 
               const executeQueryUsecase = new ExecuteQueryUseCaseImpl(datamartRepository, catalogQueryRepository, queryAccessRepository);
 
@@ -182,7 +186,11 @@ describe('Unit | Domain | Usecases | ExecuteQueryUsecase', function () {
 
               // then
               expect(result.isSuccess).to.be.true;
-              expect(result.resultData.result).to.deep.equal(expectedResult);
+              const data = [];
+              for await (const row of result.resultData.result) {
+                data.push(row.toString());
+              }
+              expect(data).to.deep.equal([expectedResult]);
             });
           });
         });


### PR DESCRIPTION
## :unicorn: Problème
Lorsque qu'une requête ramène beaucoup de données le container traitant la requête crashe. Cela s'explique par le fait que le contenu de la réponse est montée en mémoire avant d'être renvoyé par Hapi.js au client. 

## :robot: Proposition
Passer les requêtes qui peuvent être volumineuse en stream, ce qui a l'avantage de ne pas monter toutes la donnée en mémoire. 
Pour faire cela, la doc de knex dit qu'il faut installer `pg-query-stream`, puis nous devons tout passer en readable stream sur les couches d'au dessus, dans notre cas dans le controller. 

## :rainbow: Remarques
Il a été nécessaire d'ajouter `pg-query-stream` dans le fichier `.depcheckrc` car knex utilise la librairie uniquement dans son code et depcheck ne le vérifie donc pas. 

On peut voir que la méthode find n'est plus asynchrone car elle retourne directement un stream.

## :100: Pour tester
- Récupérer un token 
```shell
ACCESS_TOKEN=$(curl -v -X POST https://pix-api-data-integration-pr32.osc-fr1.scalingo.io/token -H 'Content-Type: application/json' --data $'{ "username": "dev", "password": "<password>" }' | jq -r .data.access_token)
```

- Lancer la requête faite pour l'occasion qui prends bcp de place et voir que le container Scalingo ne subit pas trop et que la réponse est bien streamée 
```shell
curl -X POST https://pix-api-data-integration-pr32.osc-fr1.scalingo.io/query -H 'Content-Type: application/json' -H "Authorization: Bearer $ACCESS_TOKEN" --data $'{ "queryId": "b1e20492-8775-47f3-926d-3729ee2b836d", "params": [] }'
```