### PR TITLE
[FEATURE] Retourner du csv si l'utilisateur le souhaite (PIX-14238).

### DIFF
--- a/lib/application/query/query.ts
+++ b/lib/application/query/query.ts
@@ -1,5 +1,7 @@
+import { Readable } from 'node:stream';
 import type { Request, ResponseObject, ResponseToolkit } from '@hapi/hapi';
 
+import { Transform } from '@json2csv/node';
 import { UserCommand } from '../../domain/commands/UserCommand.js';
 import type { Result } from '../../domain/models/Result.js';
 import { executeQueryUseCase } from '../../domain/usecases/ExecuteQueryUsecase.js';
@@ -28,7 +30,15 @@ export async function execute(
       .code(422);
   }
 
+  if (clientRequest.headers.accept === 'text/csv') {
+    const parser = new Transform({}, {}, { objectMode: true });
+
+    // cf: https://github.com/hapijs/hapi/issues/3733#issuecomment-361944940
+    const wrappedStream = new Readable().wrap(queryExecutionResult.resultData.result.pipe(parser));
+    return h.response(wrappedStream).type('text/csv');
+  }
+
   return h.response(
     APIResponse.successStream(queryExecutionResult.resultData.result),
-  ).type('application.json');
+  ).type('application/json');
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@hapi/hapi": "^21.3.2",
         "@hapi/inert": "^7.0.0",
         "@hapi/vision": "^7.0.0",
+        "@json2csv/node": "^7.0.6",
         "bcrypt": "^5.1.0",
         "dotenv": "^16.3.1",
         "hapi-swagger": "^17.2.1",
@@ -1568,6 +1569,28 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
       "license": "MIT"
     },
+    "node_modules/@json2csv/formatters": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@json2csv/formatters/-/formatters-7.0.6.tgz",
+      "integrity": "sha512-hjIk1H1TR4ydU5ntIENEPgoMGW+Q7mJ+537sDFDbsk+Y3EPl2i4NfFVjw0NJRgT+ihm8X30M67mA8AS6jPidSA=="
+    },
+    "node_modules/@json2csv/node": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@json2csv/node/-/node-7.0.6.tgz",
+      "integrity": "sha512-J3AX8cDBeQyriJj0oFxJot52hScUN4hhUBRnUGIPt+yI1YpwUuftriJi1RJS60Uz6Stce1sewHeG56dBc9/XGg==",
+      "dependencies": {
+        "@json2csv/plainjs": "^7.0.6"
+      }
+    },
+    "node_modules/@json2csv/plainjs": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@json2csv/plainjs/-/plainjs-7.0.6.tgz",
+      "integrity": "sha512-4Md7RPDCSYpmW1HWIpWBOqCd4vWfIqm53S3e/uzQ62iGi7L3r34fK/8nhOMEe+/eVfCx8+gdSCt1d74SlacQHw==",
+      "dependencies": {
+        "@json2csv/formatters": "^7.0.6",
+        "@streamparser/json": "^0.0.20"
+      }
+    },
     "node_modules/@mapbox/node-pre-gyp": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
@@ -1714,6 +1737,11 @@
       "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
       "dev": true,
       "license": "(Unlicense OR Apache-2.0)"
+    },
+    "node_modules/@streamparser/json": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@streamparser/json/-/json-0.0.20.tgz",
+      "integrity": "sha512-VqAAkydywPpkw63WQhPVKCD3SdwXuihCUVZbbiY3SfSTGQyHmwRoq27y4dmJdZuJwd5JIlQoMPyGvMbUPY0RKQ=="
     },
     "node_modules/@stylistic/eslint-plugin": {
       "version": "2.6.4",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@hapi/hapi": "^21.3.2",
     "@hapi/inert": "^7.0.0",
     "@hapi/vision": "^7.0.0",
+    "@json2csv/node": "^7.0.6",
     "bcrypt": "^5.1.0",
     "dotenv": "^16.3.1",
     "hapi-swagger": "^17.2.1",

--- a/tests/acceptance/application/query_test.ts
+++ b/tests/acceptance/application/query_test.ts
@@ -127,6 +127,38 @@ describe('Acceptance | query', function () {
             messages: [],
           });
         });
+
+        context('when user request response in csv', function () {
+          it('should return a csv response with status code 200', async function () {
+            // given
+            const queryId = '26f6efcc-ce13-4b20-b6ea-5bebae6115af';
+            await knexAPI('catalog_queries').insert({
+              id: queryId,
+              sql_query: `SELECT COUNT(*) as count, 'A' as value FROM public.data_ref_academies UNION SELECT 10, 'B'`,
+            });
+            await knexAPI('query_access').insert({
+              query_id: queryId,
+              user_id: userId,
+            });
+            const payload = {
+              queryId,
+              params: <any>[],
+            };
+
+            // when
+            const server = await createServer();
+            const response = await server.inject({
+              method: 'POST',
+              url: '/query',
+              payload,
+              headers: { authorization: headers, accept: 'text/csv' },
+            });
+
+            // then
+            expect(response.statusCode).to.equal(200);
+            expect(response.payload).to.deep.equal('"count","value"\n10,"B"\n33,"A"');
+          });
+        });
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, l'API retourne les résultats d'une requête de données uniquement en JSON, cela peut être contraignant pour certains de nos partenaires.

## :robot: Proposition
Proposer de retourner le resultat en csv si l'utilisateur le demande. Pour ça nous nous basons sur [le header `Accept`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept) prévu à cet effet. 

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- Récupérer un token 
```shell
ACCESS_TOKEN=$(curl -v -X POST https://pix-api-data-integration-pr33.osc-fr1.scalingo.io/token -H 'Content-Type: application/json' --data $'{ "username": "dev", "password": "<password>" }' | jq -r .data.access_token)
```

- Faire un appel une requête comme avant 
```shell
curl -X POST https://pix-api-data-integration-pr33.osc-fr1.scalingo.io/query -H 'Content-Type: application/json' -H "Authorization: Bearer $ACCESS_TOKEN" --data $'{ "queryId": "b1e20492-8775-47f3-926d-3729ee2b836d", "params": [{"name":"id_list", "value": [1] }] }'
```

- Faire l'appel en demandant n'importe quel type et voir que c'est du json 
```shell
curl -X POST https://pix-api-data-integration-pr33.osc-fr1.scalingo.io/query -H 'Accept: toto/toto' -H 'Content-Type: application/json' -H "Authorization: Bearer $ACCESS_TOKEN" --data $'{ "queryId": "b1e20492-8775-47f3-926d-3729ee2b836d", "params": [{"name":"id_list", "value": [4] }] }'
```

- Faire l'appel en demandant du csv
```shell
curl -X POST https://pix-api-data-integration-pr33.osc-fr1.scalingo.io/query -H 'Accept: text/csv' -H 'Content-Type: application/json' -H "Authorization: Bearer $ACCESS_TOKEN" --data $'{ "queryId": "b1e20492-8775-47f3-926d-3729ee2b836d", "params": [{"name":"id_list", "value": [4] }] }'
```