### PR TITLE
[DOC] Utiliser le swagger en étant connecté

### DIFF
--- a/lib/infrastructure/plugins/swagger.ts
+++ b/lib/infrastructure/plugins/swagger.ts
@@ -9,5 +9,14 @@ export const swaggerPlugin = {
       title: 'API Data Documentation',
       version: packageJson.version,
     },
+    securityDefinitions: {
+      Bearer: {
+        'type': 'apiKey',
+        'name': 'Authorization',
+        'in': 'header',
+        'x-keyPrefix': 'Bearer ',
+      },
+    },
+    security: [{ Bearer: [] }],
   },
 };


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, l'interface du swagger n'est pas utilisable car la route /query nécessite d'être connectée et le swagger ne le permets pas 

## :robot: Proposition
Ajouter ce qu'il faut 

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
Se rendre sur `/documentation` voir le petit cadenas et ajouter un bearer et utiliser `/query`