### PR TITLE
[TECH] Marquer le bon déploiement Scalingo comme nécessaire au merge

### DIFF
--- a/.github/workflows/wait-for-status-checks.yml
+++ b/.github/workflows/wait-for-status-checks.yml
@@ -1,0 +1,41 @@
+name: wait-for-status-checks
+on:
+  pull_request:
+  status: {}
+jobs:
+  enforce-all-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Use correct sha
+        run: |
+          echo "before: $GITHUB_SHA"
+          if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
+           GITHUB_SHA=${{ github.event.pull_request.head.sha }}
+          fi
+          echo COMMIT_SHA=$GITHUB_SHA >> $GITHUB_ENV
+          echo "after: $GITHUB_SHA"
+
+      - name: Wait for status checks
+        run: |
+          STATUS="pending"
+          echo "Listen for commit $COMMIT_SHA"
+          WAITED="0"
+          SLEEP_TIME="60"
+          while [ "$STATUS" == "pending" ] && [ "$WAITED" -le 240 ]
+          do
+            sleep ${SLEEP_TIME}
+            WAITED=$((WAITED+SLEEP_TIME))
+            STATUS=$(gh api /repos/${{ github.repository  }}/commits/"${COMMIT_SHA}"/status -q .state)
+          echo "status : $STATUS"
+          echo "waited  $WAITED s"
+          done
+          echo "status : $STATUS"
+          if [ "$STATUS" != "success" ]
+            then exit 1
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}


### PR DESCRIPTION
## :unicorn: Problème
Le bon déploiement des RA n'est pas bloquant pour le merge, ce qui est problématique par exemple pour l'auto-merge des PRs renovate ou encore lors d'un rebase fait pas l'action `auto-merge`. De plus, il est difficile de marquer facilement le déploiement de la RA sur Scalingo comme bloquant, car le nom du check étant différent pour chaque PR nous pouvons pas l'ajouter aux checks obligatoire dans les protections de branches. 

![Screenshot 2024-09-24 at 12 15 16](https://github.com/user-attachments/assets/8d3eb6a8-c4db-44f4-bc29-aa68cb28e291)

De plus, le déploiement de la RA sur Scalingo, ne fait pas partie de la check-suite, mais fait partie des status du commits (voir [cette réponse StackOverflow](https://stackoverflow.com/questions/67919168/github-checks-api-vs-check-runs-vs-check-suites/72312617#72312617) pour comprendre la différence), ce qui rend la tâche plus compliqué. 

## :robot: Proposition


## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
