### PR TITLE
[TECH] Remonter les métriques du container et des pools de connexions

### DIFF
--- a/lib/common/config.ts
+++ b/lib/common/config.ts
@@ -17,6 +17,7 @@ export interface Logging {
   enabled: boolean;
   logLevel: string;
   logForHumans: boolean;
+  opsEventIntervalInSeconds: number;
 }
 export interface Authentication {
   accessTokenLifespan: string;
@@ -48,6 +49,7 @@ function buildConfiguration(): Config {
       enabled: isFeatureEnabled(env.LOG_ENABLED),
       logLevel: env.LOG_LEVEL || 'info',
       logForHumans: _getLogForHumans(),
+      opsEventIntervalInSeconds: _getNumber(env.OPS_EVENT_INTERVAL_IN_SECONDS, 15),
     },
     authentication: {
       accessTokenLifespan: env.ACCESS_TOKEN_LIFESPAN || '20m',

--- a/lib/server.ts
+++ b/lib/server.ts
@@ -2,10 +2,13 @@ import { env } from 'node:process';
 import type { Server, ServerOptions } from '@hapi/hapi';
 import Hapi from '@hapi/hapi';
 
+import Oppsy from '@1024pix/oppsy';
+import { knexAPI, knexDatamart } from './common/db/knex-database-connections.js';
 import { authentication } from './infrastructure/authentication.js';
 import { plugins } from './infrastructure/plugins/plugins.js';
 import { routes } from './routes.js';
 import { handleDomainAndHttpErrors } from './application/pre-response-utils.js';
+import { config } from './common/config.js';
 
 const createBareServer = function (): Server {
   const serverConfiguration: ServerOptions = {
@@ -51,11 +54,41 @@ const setupErrorHandling = function (server: Server) {
   server.ext('onPreResponse', handleDomainAndHttpErrors);
 };
 
+const enableOpsMetrics = function (server) {
+  const oppsy = new Oppsy(server);
+
+  oppsy.on('ops', (data) => {
+    const apiKnexPool = knexAPI.client.pool;
+    const datamartKnexPool = knexDatamart.client.pool;
+    server.log(['ops'], {
+      ...data,
+      knexPool: {
+        apiData: {
+          used: apiKnexPool.numUsed(),
+          free: apiKnexPool.numFree(),
+          pendingAcquires: apiKnexPool.numPendingAcquires(),
+          pendingCreates: apiKnexPool.numPendingCreates(),
+        },
+        datamart: {
+          used: datamartKnexPool.numUsed(),
+          free: datamartKnexPool.numFree(),
+          pendingAcquires: datamartKnexPool.numPendingAcquires(),
+          pendingCreates: datamartKnexPool.numPendingCreates(),
+        },
+      },
+    });
+  });
+
+  oppsy.start(config.logging.opsEventIntervalInSeconds * 1000);
+  server.oppsy = oppsy;
+};
+
 async function createServer(): Promise<Server> {
   const server = createBareServer();
   setupErrorHandling(server);
   setupAuthentication(server);
   await setupRoutesAndPlugins(server);
+  enableOpsMetrics(server);
   return server;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {
+        "@1024pix/oppsy": "^1.0.1",
         "@hapi/boom": "^10.0.1",
         "@hapi/hapi": "^21.3.2",
         "@hapi/inert": "^7.0.0",
@@ -59,6 +60,17 @@
       "engines": {
         "node": "20.15.1",
         "npm": "^10.7.0"
+      }
+    },
+    "node_modules/@1024pix/oppsy": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/oppsy/-/oppsy-1.0.1.tgz",
+      "integrity": "sha512-sz5YQ3DgCd0Ius5W0Divbiu+AxQ39XwjPObq9zJkWXQBQrZheCeVhP4kOA9ZCWa2CZOEvRCmu/MTtElPsyTaIw==",
+      "dependencies": {
+        "@hapi/hoek": "11.x.x"
+      },
+      "engines": {
+        "node": "^16 || ^18 || ^20 || ^22"
       }
     },
     "node_modules/@antfu/eslint-config": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "test:lint": "npm test && npm run lint"
   },
   "dependencies": {
+    "@1024pix/oppsy": "^1.0.1",
     "@hapi/boom": "^10.0.1",
     "@hapi/hapi": "^21.3.2",
     "@hapi/inert": "^7.0.0",


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, aucune métrique n'est loggé. Ce qui ne nous permet pas de les exploiter dans Datadog. Nous ne pouvons donc pas voir si nous avons des fuites mémoires, une utilisation excessive du CPU, ni voir l'état des pools de connexions. Cela rend donc difficiles le débuggage et la future mise en place de l'auto-scaling. 

## :robot: Proposition
Faire comme sur l'API de Pix, mettre en place notre fork du plugin oopsy en faisant bien la configuration pour qu'il log les 2 connexions différentes.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
Se rendre sur le dashboard Scalingo et voir dans les logs des logs à intervalle régulier.

![Screenshot 2024-09-23 at 16 02 22](https://github.com/user-attachments/assets/42c0a1bf-aaf9-44ee-ad13-37c1a226fccb)
