### PR TITLE
[TECH] Réduire la taille du bundle Scalingo

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,0 +1,14 @@
+.circleci
+.github
+data
+docs
+tests
+
+.depcheckrc
+.mocharc.json
+.nvmrc
+.prettierrc
+docker-compose.yaml
+eslint.config.js
+sample.env
+renovate.json


### PR DESCRIPTION
## :unicorn: Problème
La taille du bundle Scalingo fait environ 200Mo, alors que tout n'est pas utile 💚 💻  

## :robot: Proposition
Supprimer les fichiers inutiles en utilisant [un fichier .slugignore](https://doc.scalingo.com/platform/app/slugignore)

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- Regarder la taille d'un build de prod vs celui de la RA