### PR TITLE
[FEATURE] Nommer les requêtes du catalogue

### DIFF
--- a/lib/common/db/migrations/20240925085000_add-name-col-to-catalog-queries.js
+++ b/lib/common/db/migrations/20240925085000_add-name-col-to-catalog-queries.js
@@ -1,0 +1,18 @@
+const TABLE_NAME = 'catalog_queries';
+
+const up = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, (t) => {
+    t.string('name')
+      .comment('Nom de la requête');
+  });
+  await knex(TABLE_NAME).update({ name: '' });
+  return knex.raw(`alter table ${TABLE_NAME} alter column name set NOT NULL`);
+};
+
+const down = function (knex) {
+  return knex.schema.alterTable(TABLE_NAME, (t) => {
+    t.dropColumn('name');
+  });
+};
+
+export { down, up };

--- a/lib/common/db/seeds/seed.js
+++ b/lib/common/db/seeds/seed.js
@@ -7,6 +7,7 @@ function _getNumber(numberAsString, defaultValue) {
 }
 const seed = async function (knex) {
   await knex('catalog_queries').insert({
+    name: 'Nombre d\'académies',
     sql_query: 'SELECT COUNT(*) FROM data_ref_academies',
     id: '1b7291d4-ac51-46d2-97f1-f5f304100a29',
     created_at: new Date('2021-10-29T03:04:00Z'),
@@ -15,6 +16,7 @@ const seed = async function (knex) {
   const refAcademiesQueryId = 'b1e20492-8775-47f3-926d-3729ee2b836d';
 
   await knex('catalog_queries').insert({
+    name: 'Académies filtrées par liste d\'id',
     sql_query:
       'SELECT id, nom, region, departements FROM data_ref_academies WHERE id = any({{ id_list }})',
     id: refAcademiesQueryId,

--- a/scripts/prod/add-queries-from-csv.ts
+++ b/scripts/prod/add-queries-from-csv.ts
@@ -38,6 +38,7 @@ const parseMe = yargs(hideBin(process.argv))
   .help();
 
 class QueryChecker {
+  name: string;
   query: string;
   mandatoryParamsInQuery: string[];
   optionalParamsInQuery: string[];
@@ -46,12 +47,14 @@ class QueryChecker {
   isValid: boolean;
 
   constructor(
+    name: string,
     query: string,
     mandatoryParamsInQuery: string[],
     optionalParamsInQuery: string[],
     lineNumberInCSV: number,
     providedParams: ProvidedParam[],
   ) {
+    this.name = name;
     this.query = query;
     this.mandatoryParamsInQuery = mandatoryParamsInQuery;
     this.optionalParamsInQuery = optionalParamsInQuery;
@@ -61,18 +64,23 @@ class QueryChecker {
   }
 
   static fromCSVLine(csvLine: string[], lineNumber: number): QueryChecker {
-    const query = csvLine[0];
+    const name = csvLine[0].trim();
+    if (name.length === 0) {
+      return new QueryChecker('', '', [], [], lineNumber, []);
+    }
+    const query = csvLine[1];
     if (query.trim().length === 0) {
-      return new QueryChecker('', [], [], lineNumber, []);
+      return new QueryChecker('', '', [], [], lineNumber, []);
     }
     const { queryWithoutOptionalBlocks, optionalParams }
       = extractOptionalParameters(query);
     const { mandatoryParams } = extractMandatoryParameters(
       queryWithoutOptionalBlocks,
     );
-    const providedParams = parseProvidedParameters(csvLine.slice(1));
+    const providedParams = parseProvidedParameters(csvLine.slice(2));
 
     return new QueryChecker(
+      name,
       query,
       mandatoryParams,
       optionalParams,
@@ -211,6 +219,7 @@ async function addQueryToCatalog(
   const sqlQueries: string[] = [];
   const knexQueryToExecute_query = trx('catalog_queries')
     .insert({
+      name: queryChecker.name,
       sql_query: queryChecker.query,
     })
     .returning('id');

--- a/tests/acceptance/application/query_test.ts
+++ b/tests/acceptance/application/query_test.ts
@@ -64,6 +64,7 @@ describe('Acceptance | query', function () {
           await knexAPI('catalog_queries').insert({
             id: queryId,
             sql_query: 'SELECT COUNT(*) FROM public.data_ref_academies UNION SELECT 1;',
+            name: 'foo',
           });
           await knexAPI('query_access').insert({
             query_id: queryId,
@@ -100,6 +101,7 @@ describe('Acceptance | query', function () {
           await knexAPI('catalog_queries').insert({
             id: queryId,
             sql_query: 'SELECT COUNT(*) FROM public.data_ref_academies',
+            name: 'foo',
           });
           await knexAPI('query_access').insert({
             query_id: queryId,
@@ -135,6 +137,7 @@ describe('Acceptance | query', function () {
             await knexAPI('catalog_queries').insert({
               id: queryId,
               sql_query: `SELECT COUNT(*) as count, 'A' as value FROM public.data_ref_academies UNION SELECT 10, 'B'`,
+              name: 'foo',
             });
             await knexAPI('query_access').insert({
               query_id: queryId,
@@ -170,6 +173,7 @@ describe('Acceptance | query', function () {
         await knexAPI('catalog_queries').insert({
           id: otherQueryId,
           sql_query: 'SELECT COUNT(*) FROM public.data_ref_academies',
+          name: 'foo',
         });
         const payload = {
           queryId,

--- a/tests/integration/infrastructure/repositories/QueryAccessRepository_test.ts
+++ b/tests/integration/infrastructure/repositories/QueryAccessRepository_test.ts
@@ -43,6 +43,7 @@ describe('Integration | Repositories | QueryAccessRepository', function () {
       await knexAPI('catalog_queries').insert({
         id: queryId,
         sql_query: 'SELECT * FROM public.data_ref_academies LIMIT {{ limit}}',
+        name: 'foo',
       });
       await knexAPI('catalog_query_params').insert({
         id: queryParamId,

--- a/tests/integration/scripts/prod/add-queries-from-csv_test.ts
+++ b/tests/integration/scripts/prod/add-queries-from-csv_test.ts
@@ -105,11 +105,11 @@ describe('Integration | scripts-prod | Add queries from csv', function () {
       expect(insertedQueriesCnt).to.equal(0);
       expect(insertedQueryParamsCnt).to.equal(0);
       expect(sqlByQuery[0]).to.have.members([
-        `insert into "catalog_queries" ("sql_query") values ('select * from t where id = 1') returning "id"`,
+        `insert into "catalog_queries" ("name", "sql_query") values ('foo 1', 'select * from t where id = 1') returning "id"`,
       ]);
       sinon.assert.match(
         sqlByQuery[1][0],
-        `insert into "catalog_queries" ("sql_query") values ('select * from t where id = {{ mandatoryParam }} [[ AND optional = {{ optionalParam }} ]] [[ AND optional2 = {{ optionalParam2 }} ]]') returning "id"`,
+        `insert into "catalog_queries" ("name", "sql_query") values ('foo 2', 'select * from t where id = {{ mandatoryParam }} [[ AND optional = {{ optionalParam }} ]] [[ AND optional2 = {{ optionalParam2 }} ]]') returning "id"`,
       );
       sinon.assert.match(
         sqlByQuery[1][1],

--- a/tests/integration/scripts/prod/queries-checkonly-test.csv
+++ b/tests/integration/scripts/prod/queries-checkonly-test.csv
@@ -1,12 +1,12 @@
-"","{name:'mandatoryParam', type: 'int', mandatory: 'true'}"
-"select * from t where id = {{ mandatoryParam }}",
-"select * from t where id = {{ mandatoryParam }}","{name:'mandatory_param', type: 'int', mandatory: 'true'}",
-"select * from t where id = {{ mandatoryParam }}","{name : 'mandatoryParam', type: 'imaginary-type', mandatory: 'true'}",
-"select * from t where id = {{ mandatoryParam }}","{name:""mandatoryParam"", type: 'int', mandatory: 'false'}",
-"select * from t where id = 1 [[ AND optional = {{ optionalParam }} ]]",
-"select * from t where id = 1 [[ AND optional = {{ optionalParam }} ]]","{name:'optional_param', type: 'string', mandatory: 'false'}",
-"select * from t where id = 1 [[ AND optional = {{ optionalParam }} ]]","{name: optionalParam, type: 'imaginary-type', mandatory: 'false'}",
-"select * from t where id = 1 [[ AND optional = {{ optionalParam }} ]]","{name:'optionalParam', type: 'string', mandatory: 'true'}",
-"select * from t where id = 1","{name:'mandatoryParam', type: 'string', mandatory: 'true'}",
-"select * from t where id = 1",
-"select * from t where id = {{ mandatoryParam }} [[ AND optional = {{ optionalParam }} ]] [[ AND optional2 = {{ optionalParam2 }} ]]","{name:'mandatoryParam', type: 'int', mandatory: 'true'}","{name:'optionalParam', type: 'string', mandatory: 'false'}","{name:'optionalParam2', type: 'date-time', mandatory: 'false'}"
+"foo","","{name:'mandatoryParam', type: 'int', mandatory: 'true'}"
+"foo","select * from t where id = {{ mandatoryParam }}",
+"foo","select * from t where id = {{ mandatoryParam }}","{name:'mandatory_param', type: 'int', mandatory: 'true'}",
+"foo","select * from t where id = {{ mandatoryParam }}","{name : 'mandatoryParam', type: 'imaginary-type', mandatory: 'true'}",
+"foo","select * from t where id = {{ mandatoryParam }}","{name:""mandatoryParam"", type: 'int', mandatory: 'false'}",
+"foo","select * from t where id = 1 [[ AND optional = {{ optionalParam }} ]]",
+"foo","select * from t where id = 1 [[ AND optional = {{ optionalParam }} ]]","{name:'optional_param', type: 'string', mandatory: 'false'}",
+"foo","select * from t where id = 1 [[ AND optional = {{ optionalParam }} ]]","{name: optionalParam, type: 'imaginary-type', mandatory: 'false'}",
+"foo","select * from t where id = 1 [[ AND optional = {{ optionalParam }} ]]","{name:'optionalParam', type: 'string', mandatory: 'true'}",
+"foo","select * from t where id = 1","{name:'mandatoryParam', type: 'string', mandatory: 'true'}",
+"foo","select * from t where id = 1",
+"foo","select * from t where id = {{ mandatoryParam }} [[ AND optional = {{ optionalParam }} ]] [[ AND optional2 = {{ optionalParam2 }} ]]","{name:'mandatoryParam', type: 'int', mandatory: 'true'}","{name:'optionalParam', type: 'string', mandatory: 'false'}","{name:'optionalParam2', type: 'date-time', mandatory: 'false'}"

--- a/tests/integration/scripts/prod/queries-dryrun-test.csv
+++ b/tests/integration/scripts/prod/queries-dryrun-test.csv
@@ -1,2 +1,2 @@
-"select * from t where id = 1",
-"select * from t where id = {{ mandatoryParam }} [[ AND optional = {{ optionalParam }} ]] [[ AND optional2 = {{ optionalParam2 }} ]]","{name:'mandatoryParam', type: 'int', mandatory: 'true'}","{name:'optionalParam', type: 'string', mandatory: 'false'}","{name:'optionalParam2', type: 'date-time', mandatory: 'false'}"
+"foo 1","select * from t where id = 1",
+"foo 2","select * from t where id = {{ mandatoryParam }} [[ AND optional = {{ optionalParam }} ]] [[ AND optional2 = {{ optionalParam2 }} ]]","{name:'mandatoryParam', type: 'int', mandatory: 'true'}","{name:'optionalParam', type: 'string', mandatory: 'false'}","{name:'optionalParam2', type: 'date-time', mandatory: 'false'}"

--- a/tests/integration/scripts/prod/queries-failexec-test.csv
+++ b/tests/integration/scripts/prod/queries-failexec-test.csv
@@ -1,2 +1,2 @@
-"select * from t where id = 1",
-"select * from t where id = {{ mandatory_Param }} [[ AND optional = {{ optionalParam }} ]] [[ AND optional2 = {{ optionalParam2 }} ]]","{name:'mandatoryParam', type: 'int', mandatory: 'true'}","{name:'optionalParam', type: 'string', mandatory: 'false'}","{name:'optionalParam2', type: 'date-time', mandatory: 'false'}"
+"foo","select * from t where id = 1",
+"foo","select * from t where id = {{ mandatory_Param }} [[ AND optional = {{ optionalParam }} ]] [[ AND optional2 = {{ optionalParam2 }} ]]","{name:'mandatoryParam', type: 'int', mandatory: 'true'}","{name:'optionalParam', type: 'string', mandatory: 'false'}","{name:'optionalParam2', type: 'date-time', mandatory: 'false'}"

--- a/tests/integration/scripts/prod/queries-successexec-test.csv
+++ b/tests/integration/scripts/prod/queries-successexec-test.csv
@@ -1,2 +1,2 @@
-"select * from t where id = 1",
-"select * from t where id = {{ mandatoryParam }} [[ AND optional = {{ optionalParam }} ]] [[ AND optional2 = {{ optionalParam2 }} ]]","{name:'mandatoryParam', type: 'int', mandatory: 'true'}","{name:'optionalParam', type: 'string', mandatory: 'false'}","{name:'optionalParam2', type: 'date-time', mandatory: 'false'}"
+"foo","select * from t where id = 1",
+"foo","select * from t where id = {{ mandatoryParam }} [[ AND optional = {{ optionalParam }} ]] [[ AND optional2 = {{ optionalParam2 }} ]]","{name:'mandatoryParam', type: 'int', mandatory: 'true'}","{name:'optionalParam', type: 'string', mandatory: 'false'}","{name:'optionalParam2', type: 'date-time', mandatory: 'false'}"


### PR DESCRIPTION
## :fallen_leaf: Problème
Il est difficile de comprendre à quoi correspond une requête enregistrée dans `catalog_queries`.

## :chestnut: Proposition
Ajouter un champ `name` permettant de nommer la requête.

## :jack_o_lantern: Remarques
Ce champ est obligatoire (non nullable), pour les enregistrements déjà présents en base une chaîne de caractère vide est insérée.

## :wood:  Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
